### PR TITLE
Update Data types link

### DIFF
--- a/docs/en/recipes/telemetry.md
+++ b/docs/en/recipes/telemetry.md
@@ -7,7 +7,7 @@ they are consumed:
 ![telemetry concept](images/telemetry.png)
 
 !!! success
-    See the [Data types](/signals/logs) section for a detailed breakdown of the best practices for each type of telemetry.
+    See the [Data types](../signals/logs) section for a detailed breakdown of the best practices for each type of telemetry.
 
 Let's further dive into the concepts introduced in above figure.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Link `(/signals/logs)` didn't work, from what I could see in the other [file](https://github.com/aws-observability/observability-best-practices/blob/main/docs/en/guides/index.md?plain=1#L35) the correct link is `(../signals/logs)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

