### PR TITLE
Fix: fix typo in ADOT FAQ

### DIFF
--- a/docs/en/faq/adot.md
+++ b/docs/en/faq/adot.md
@@ -8,8 +8,8 @@
     We have a [Performance Report](https://aws-observability.github.io/aws-otel-collector/benchmark/report) online that we keep up to date as we release collectors.
 1. **Is it possible to use ADOT with Apache Kafka?**
     Yes, support to Kafka exporter and receiver was added in the ADOT collector v0.28.0. For more details, please check the [ADOT collector documentation](https://aws-otel.github.io/docs/components/kafka-receiver-exporter).
-1. **How can I can configure the ADOT collector?**
-    The default mechanism to configure the ADOT collector is through configuration files. There are additional mechanisms, like storing configurations in S3 buckets, that are described in detail in the [ADOT collector documentation](https://aws-otel.github.io/docs/components/confmap-providers).
+1. **How can I configure the ADOT collector?**
+    The ADOT collector is configured using YAML configuration files that are stored locally. Besides that, it is possible to use configuration stored in other locations, like S3 buckets. All the supported mechanisms to configure the ADOT collector are described in detail in the [ADOT collector documentation](https://aws-otel.github.io/docs/components/confmap-providers).
 1. **Can I do advanced sampling in the ADOT collector?**
     We’re working on it, please subscribe to the public [roadmap entry](https://github.com/aws-observability/aws-otel-collector/issues/1135) to keep up to date.
 1. **Any tips how to scale the ADOT collector?**


### PR DESCRIPTION

*Description of changes:* Fix: fix typo in ADOT FAQ.

@awsimaya can you take a look?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

