### PR TITLE
Fix Nodejs link

### DIFF
--- a/docs/en/recipes/nodejs.md
+++ b/docs/en/recipes/nodejs.md
@@ -4,5 +4,5 @@
 - [NodeJS library to generate embedded CloudWatch metrics][node-cw]
 
 
-[node-cw]: https://observability.workshop.aws/en/emf.html
+[node-cw]: https://catalog.workshops.aws/observability/en-US/aws-native/metrics/emf/clientlibrary
 


### PR DESCRIPTION
Fixing broken URL in https://aws-observability.github.io/observability-best-practices/recipes/nodejs/ 
