### PR TITLE
Fix repository on Recipe - CWMetricStreamExporter

### DIFF
--- a/docs/en/recipes/recipes/lambda-cw-metrics-go-amp.md
+++ b/docs/en/recipes/recipes/lambda-cw-metrics-go-amp.md
@@ -18,7 +18,7 @@ HTTP endpoint or [S3 bucket](https://aws.amazon.com/s3).
 * The AWS CLI is [installed](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) in your environment.
 * The [AWS CDK Typescript](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-typescript.html) is installed in your environment.
 * Node.js and Go.
-* The [repo](https://github.com/aws-observability/aws-o11y-recipes/) has been cloned to your local machine.
+* The [repo](https://github.com/aws-observability/observability-best-practices/) has been cloned to your local machine.
 
 ### Create an AMP workspace
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Recipe points to the previous repository (Archived).
Point to the current repository `https://github.com/aws-observability/observability-best-practices/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

