### PR TITLE
Update Grafana dashboard refresh intevals from 10s->60s

### DIFF
--- a/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/apiserver/apiserver-advanced.json
+++ b/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/apiserver/apiserver-advanced.json
@@ -1700,7 +1700,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "10s",
+  "refresh": "60s",
   "revision": 1,
   "schemaVersion": 38,
   "style": "dark",

--- a/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/apiserver/apiserver-basic.json
+++ b/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/apiserver/apiserver-basic.json
@@ -591,7 +591,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "10s",
+  "refresh": "60s",
   "revision": 1,
   "schemaVersion": 38,
   "style": "dark",

--- a/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/cluster.json
+++ b/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/cluster.json
@@ -2989,7 +2989,7 @@
       "type": "table"
     }
   ],
-  "refresh": "10s",
+  "refresh": "60s",
   "revision": 1,
   "schemaVersion": 38,
   "style": "dark",

--- a/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/kubelet.json
+++ b/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/kubelet.json
@@ -2116,7 +2116,7 @@
       }
     }
   ],
-  "refresh": "10s",
+  "refresh": "60s",
   "schemaVersion": 35,
   "style": "dark",
   "tags": [

--- a/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/namespace-workloads.json
+++ b/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/namespace-workloads.json
@@ -2510,7 +2510,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "10s",
+  "refresh": "60s",
   "schemaVersion": 35,
   "style": "dark",
   "tags": [

--- a/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/nodes.json
+++ b/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/nodes.json
@@ -1370,7 +1370,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "10s",
+  "refresh": "60s",
   "schemaVersion": 35,
   "style": "dark",
   "tags": [

--- a/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/workloads.json
+++ b/solutions/oss/eks-infra/v1.0.0/grafana-dashboards/infrastructure/workloads.json
@@ -2107,7 +2107,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "10s",
+  "refresh": "60s",
   "schemaVersion": 35,
   "style": "dark",
   "tags": [


### PR DESCRIPTION
See title. I left dashboards with no refresh interval the same (apiserver-troubleshooting and nodes)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

