### PR TITLE
[fix]-FAQ updates were not visible since they were in the ./docs/en/…

### DIFF
--- a/docusaurus/docs/faq/adot.md
+++ b/docusaurus/docs/faq/adot.md
@@ -34,7 +34,7 @@ This is an area of active development and we expect that it will mature in 2023,
 
 ## How do you monitor the health and performance of the ADOT collector?
 
-1. [Monitoring the collector](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/monitoring.md) - default metrics exposed on port 8080 that can be scraped by the Prometheus receiver
+1. [Monitoring the collector](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/observability.md) - default metrics exposed on port 8080 that can be scraped by the Prometheus receiver
 2. Using the [Node Exporter](https://prometheus.io/docs/guides/node-exporter/), running node exporter would also provide several performance and health metrics about the node, pod, and operating system the collector is running in.
 3. [Kube-state-metrics (KSM)](https://github.com/kubernetes/kube-state-metrics), KSM can also produce interesting events about the collector.
 4. [Prometheus `up` metric](https://github.com/open-telemetry/opentelemetry-collector/pull/2918)

--- a/docusaurus/docs/faq/adot.md
+++ b/docusaurus/docs/faq/adot.md
@@ -1,26 +1,44 @@
 # AWS Distro for Open Telemetry (ADOT) -  FAQ
 
-1. **Can I use the ADOT collector to ingest metrics into AMP?
-    **Yes, this functionality was introduced with the GA launch for metrics support in May 2022 and you can use the ADOT collector from EC2, via our EKS add-on, via our ECS side-car integration, and/or via our Lambda layers.
-1. **Can I use the ADOT collector to collect logs and ingest them into Amazon CloudWatch or Amazon OpenSearch?**
-    Not yet but we’re working on stabilizing logs upstream in OpenTelemetry and when the time comes, potentially later in 2023 or early 2024 we will support logs in ADOT, see also the [public roadmap entry](https://github.com/aws-observability/aws-otel-community/issues/11)
-1. **Where can I find resource usage and performance details on the ADOT collector?**
-    We have a [Performance Report](https://aws-observability.github.io/aws-otel-collector/benchmark/report) online that we keep up to date as we release collectors.
-1. **Is it possible to use ADOT with Apache Kafka?**
-    Yes, support to Kafka exporter and receiver was added in the ADOT collector v0.28.0. For more details, please check the [ADOT collector documentation](https://aws-otel.github.io/docs/components/kafka-receiver-exporter).
-1. **How can I configure the ADOT collector?**
-    The ADOT collector is configured using YAML configuration files that are stored locally. Besides that, it is possible to use configuration stored in other locations, like S3 buckets. All the supported mechanisms to configure the ADOT collector are described in detail in the [ADOT collector documentation](https://aws-otel.github.io/docs/components/confmap-providers).
-1. **Can I do advanced sampling in the ADOT collector?**
-    We’re working on it, please subscribe to the public [roadmap entry](https://github.com/aws-observability/aws-otel-collector/issues/1135) to keep up to date.
-1. **Any tips how to scale the ADOT collector?**
-    Yes! See the upstream OpenTelemetry docs on [Scaling the Collector](https://opentelemetry.io/docs/collector/scaling/).
-1. **I have a fleet of ADOT collectors, how can I manage them?**
-    This is an area of active development and  we expect that it will mature in 2023, see the upstream OpenTelemetry docs on [Management](https://opentelemetry.io/docs/collector/management/) for more details, specifically on the [Open Agent Management Protocol (OpAMP)](https://opentelemetry.io/docs/collector/management/#opamp).
-1. **How do you monitor the health and performance of the ADOT collector?**
-    1. [Monitoring the collector](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/observability.md) - default metrics exposed on port 8080 that can be scraped by the Prometheus receiver
-    2. Using the [Node Exporter](https://prometheus.io/docs/guides/node-exporter/), running node exporter would also provide several performance and health metrics about the node, pod, and operating system the collector is running in.
-    3. [Kube-state-metrics (KSM)](https://github.com/kubernetes/kube-state-metrics), KSM can also produce interesting events about the collector.
-    4. [Prometheus `up` metric](https://github.com/open-telemetry/opentelemetry-collector/pull/2918)
-    5. A simple Grafana dashboard to get started: [https://grafana.com/grafana/dashboards/12553](.)
-1. **Product FAQ** - [https://aws.amazon.com/otel/faqs/](.)
+## Can I use the ADOT collector to ingest metrics into AMP?
+
+Yes, this functionality was introduced with the GA launch for metrics support in May 2022 and you can use the ADOT collector from EC2, via our EKS add-on, via our ECS side-car integration, and/or via our Lambda layers.
+
+## Can I use the ADOT collector to collect logs and ingest them into Amazon CloudWatch or Amazon OpenSearch?
+
+Yes. [Log support](https://aws.amazon.com/about-aws/whats-new/2023/11/logs-support-aws-distro-opentelemetry/) has been available since Nov 22, 2023. You can view the [Logging Exporter](https://aws-otel.github.io/docs/components/misc-exporters) page for more details.
+
+## Where can I find resource usage and performance details on the ADOT collector?
+
+We have a [Performance Report](https://aws-observability.github.io/aws-otel-collector/benchmark/report) online that we keep up to date as we release collectors.
+
+## Is it possible to use ADOT with Apache Kafka?
+
+Yes, support to Kafka exporter and receiver was added in the ADOT collector v0.28.0. For more details, please check the [ADOT collector documentation](https://aws-otel.github.io/docs/components/kafka-receiver-exporter).
+.
+## How can I configure the ADOT collector?
+
+The ADOT collector is configured using YAML configuration files that are stored locally. Besides that, it is possible to use configuration stored in other locations, like S3 buckets. All the supported mechanisms to configure the ADOT collector are described in detail in the [ADOT collector documentation](https://aws-otel.github.io/docs/components/confmap-providers).
+
+## Can I do advanced sampling in the ADOT collector?
+
+Yes. [Advanced Sampling](https://aws.amazon.com/about-aws/whats-new/2023/05/aws-distro-opentelemetry-advanced-sampling/) launched May 15, 2023. View the [Getting Started with Advanced Sampling using AWS Distro for OpenTelemetry](https://aws-otel.github.io/docs/getting-started/advanced-sampling) page for more details.
+
+## Any tips how to scale the ADOT collector?
+
+Yes! See the upstream OpenTelemetry docs on [Scaling the Collector](https://opentelemetry.io/docs/collector/scaling/).
+
+## I have a fleet of ADOT collectors, how can I manage them?
+
+This is an area of active development and we expect that it will mature in 2023, see the upstream OpenTelemetry docs on [Management](https://opentelemetry.io/docs/collector/management/) for more details, specifically on the [Open Agent Management Protocol (OpAMP)](https://opentelemetry.io/docs/collector/management/#opamp).
+
+## How do you monitor the health and performance of the ADOT collector?
+
+1. [Monitoring the collector](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/monitoring.md) - default metrics exposed on port 8080 that can be scraped by the Prometheus receiver
+2. Using the [Node Exporter](https://prometheus.io/docs/guides/node-exporter/), running node exporter would also provide several performance and health metrics about the node, pod, and operating system the collector is running in.
+3. [Kube-state-metrics (KSM)](https://github.com/kubernetes/kube-state-metrics), KSM can also produce interesting events about the collector.
+4. [Prometheus `up` metric](https://github.com/open-telemetry/opentelemetry-collector/pull/2918)
+5. A simple Grafana dashboard to get started: [https://grafana.com/grafana/dashboards/12553]()
+
+**Product FAQ:** [https://aws.amazon.com/otel/faqs/](https://aws.amazon.com/otel/faqs/)
 

--- a/docusaurus/docs/faq/amg.md
+++ b/docusaurus/docs/faq/amg.md
@@ -1,58 +1,58 @@
 # Amazon Managed Grafana - FAQ
 
-**Why should I choose Amazon Managed Grafana?**
+## Why should I choose Amazon Managed Grafana?
 
 **[High Availability](https://docs.aws.amazon.com/grafana/latest/userguide/disaster-recovery-resiliency.html)**: Amazon Managed Grafana workspaces are highly available with multi-az replication. Amazon Managed Grafana also continuously monitors for the health of workspaces and replaces unhealthy nodes, without impacting access to the workspaces. Amazon Managed Grafana manages the availability of compute and database nodes so customers don’t have to manage the infrastructure resources required for the administration & maintenance.
 
 **[Data Security](https://docs.aws.amazon.com/grafana/latest/userguide/security.html)**: Amazon Managed Grafana encrypts the data at rest without any special configuration, third-party tools, or additional cost. [Data in-transit](https://docs.aws.amazon.com/grafana/latest/userguide/infrastructure-security.html) area also encrypted via TLS.
 
-**Which AWS regions are supported?**
+## Which AWS regions are supported?
 
 Current list of supported Regions is available in the [Supported Regions section in the documentation.](https://docs.aws.amazon.com/grafana/latest/userguide/what-is-Amazon-Managed-Service-Grafana.html#AMG-supported-Regions)
 
-**We have multiple AWS accounts in multiple regions in our Organization, does Amazon Managed Grafana work for these scenarios**
+## We have multiple AWS accounts in multiple regions in our Organization, does Amazon Managed Grafana work for these scenarios?
 
 Amazon Managed Grafana integrates with [AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html) to discover AWS accounts and resources in Organizational Units (OUs). With AWS Organizations customers can [centrally manage data source configuration and permission settings](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-and-Organizations.html) for multiple AWS accounts.
 
-**What data sources are supported in Amazon Managed Grafana?**
+## What data sources are supported in Amazon Managed Grafana?
 
 Data sources are storage backends that customers can query in Grafana to build dashboards in Amazon Managed Grafana. Amazon Managed Grafana supports about [30+ built-in data sources](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-data-sources-builtin.html) including AWS native services like Amazon CloudWatch, Amazon OpenSearch Service, AWS IoT SiteWise, AWS IoT TwinMaker, Amazon Managed Service for Prometheus, Amazon Timestream, Amazon Athena, Amazon Redshift, AWS X-Ray and many others. Additionally, [about 15+ other data sources](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-data-sources-enterprise.html) are also available for upgraded workspaces in Grafana Enterprise.
 
-**Data sources of my workloads are in private VPCs. How do I connect them to Amazon Managed Grafana securely?**
+## Data sources of my workloads are in private VPCs. How do I connect them to Amazon Managed Grafana securely?
 
 Private [data sources within a VPC](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-vpc.html) can be connected to Amazon Managed Grafana through AWS PrivateLink to keep the traffic secure. Further access control to Amazon Managed Grafana service from the [VPC endpoints](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-nac.html) can be restricted by attaching an [IAM resource policy](https://docs.aws.amazon.com/grafana/latest/userguide/VPC-endpoints.html#controlling-vpc) for [Amazon VPC endpoints](https://docs.aws.amazon.com/whitepapers/latest/aws-privatelink/what-are-vpc-endpoints.html).
 
-**What User Authentication mechanism is available in Amazon Managed Grafana?**
+## What User Authentication mechanism is available in Amazon Managed Grafana?
 
 In Amazon Managed Grafana workspace, [users are authenticated to the Grafana console](https://docs.aws.amazon.com/grafana/latest/userguide/authentication-in-AMG.html) by single sign-on using any IDP that supports Security Assertion Markup Language 2.0 (SAML 2.0) or AWS IAM Identity Center (successor to AWS Single Sign-On).
 
 > Related blog: [Fine-grained access control in Amazon Managed Grafana using Grafana Teams](https://aws.amazon.com/blogs/mt/fine-grained-access-control-in-amazon-managed-grafana-using-grafana-teams/)
 
-**What kind of automation support is available for Amazon Managed Grafana?**
+## What kind of automation support is available for Amazon Managed Grafana?
 
 Amazon Managed Grafana is [integrated with AWS CloudFormation](https://docs.aws.amazon.com/grafana/latest/userguide/creating-resources-with-cloudformation.html), which helps customers in modeling and setting up AWS resources so that customers can spend less time creating and managing resources and infrastructure in AWS. With [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html) customers can reuse templates to set up Amazon Managed Grafana resources consistently and repeatedly. Amazon Managed Grafana also has [API](https://docs.aws.amazon.com/grafana/latest/APIReference/Welcome.html)available which supports customers in automating through [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) or integrating with software/products. Amazon Managed Grafana workspaces has [HTTP APIs](https://docs.aws.amazon.com/grafana/latest/userguide/Using-Grafana-APIs.html) for automation and integration support.
 
 > Related blog: [Announcing Private VPC data source support for Amazon Managed Grafana](https://aws.amazon.com/blogs/mt/announcing-private-vpc-data-source-support-for-amazon-managed-grafana/)
 
-**My Organization uses Terraform for automation. Does Amazon Managed Grafana support Terraform?**
+## My Organization uses Terraform for automation. Does Amazon Managed Grafana support Terraform?
 Yes, [Amazon Managed Grafana supports](https://aws-observability.github.io/observability-best-practices/recipes/recipes/amg-automation-tf/) Terraform for [automation](https://registry.terraform.io/modules/terraform-aws-modules/managed-service-grafana/aws/latest)
 
 > Example: [Reference implementation for Terraform support](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples/managed-grafana-workspace)
 
-**I am using commonly used Dashboards in my current Grafana setup. Is there a way to use them on Amazon Managed Grafana rather than re-creating again?**
+## I am using commonly used Dashboards in my current Grafana setup. Is there a way to use them on Amazon Managed Grafana rather than re-creating again?
 
 Amazon Managed Grafana supports [HTTP APIs](https://docs.aws.amazon.com/grafana/latest/userguide/Using-Grafana-APIs.html) that allow you to easily automate deployment and management of Dashboards, users and much more. You can use these APIs in your GitOps/CICD processes to automate management of these resources.
 
-**Does Amazon Managed Grafana support Alerts?**
+## Does Amazon Managed Grafana support Alerts?
 
 [Amazon Managed Grafana alerting](https://docs.aws.amazon.com/grafana/latest/userguide/alerts-overview.html) provides customers with robust and actionable alerts that help learn about problems in the systems in near real time, minimizing disruption to services. Grafana includes access to an updated alerting system, Grafana alerting, that centralizes alerting information in a single, searchable view.
 
-**My Organization requires all actions be recorded for audits. Can Amazon Managed Grafana events be recorded?**
+## My Organization requires all actions be recorded for audits. Can Amazon Managed Grafana events be recorded?
 
 Amazon Managed Grafana is integrated with [AWS CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html), which provides a record of actions taken by a user, a role, or an AWS service in Amazon Managed Grafana. CloudTrail captures all [API calls for Amazon Managed Grafana](https://docs.aws.amazon.com/grafana/latest/userguide/logging-using-cloudtrail.html)as events. The calls that are captured include calls from the Amazon Managed Grafana console and code calls to the Amazon Managed Grafana API operations.
 
-**What more information is available?**
+## What additional information is available?
 
 For additional information on Amazon Managed Grafana customers can read the AWS [Documentation](https://docs.aws.amazon.com/grafana/latest/userguide/what-is-Amazon-Managed-Service-Grafana.html), go through the AWS Observability Workshop on [Amazon Managed Grafana](https://catalog.workshops.aws/observability/en-US/aws-managed-oss/amg) and also check the [product page](https://aws.amazon.com/grafana/) to know the [features](https://aws.amazon.com/grafana/features/?nc=sn&loc=2), [pricing](https://aws.amazon.com/grafana/pricing/?nc=sn&loc=3) details, latest [blog posts](https://aws.amazon.com/grafana/resources/?nc=sn&loc=4&msg-blogs.sort-by=item.additionalFields.createdDate&msg-blogs.sort-order=desc#Latest_blog_posts) and [videos](https://aws.amazon.com/grafana/resources/?nc=sn&loc=4&msg-blogs.sort-by=item.additionalFields.createdDate&msg-blogs.sort-order=desc#Videos).
 
-**Product FAQ** [https://aws.amazon.com/grafana/faqs/](https://aws.amazon.com/grafana/faqs/)
+**Product FAQ:** [https://aws.amazon.com/grafana/faqs/](https://aws.amazon.com/grafana/faqs/)

--- a/docusaurus/docs/faq/amp.md
+++ b/docusaurus/docs/faq/amp.md
@@ -1,28 +1,46 @@
 # Amazon Managed Service for Prometheus - FAQ
 
-1. **Which AWS Regions are supported currently and is it possible to collect metrics from other regions?** See our [documentation](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html) for updated list of Regions that we support. We plan to support all commercial regions in 2023. Please let us know which regions you would like so that we can better prioritize our existing Product Feature Requests (PFRs). You can always collect data from any regions and send it to a specific region that we support. Here’s a blog for more details: [Cross-region metrics collection for Amazon Managed Service for Prometheus](https://aws.amazon.com/blogs/opensource/set-up-cross-region-metrics-collection-for-amazon-managed-service-for-prometheus-workspaces/).
-1. **How long does it take to see metering and/or billing in Cost Explorer or **** [CloudWatch as AWS billing charges](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html)?**
-    We meter blocks of ingested metric samples as soon as they are uploaded to S3 every 2 hours. It can take up to 3 hours to see metering and charges reported for Amazon Managed Service for Prometheus.
-1. **As far as I can see the Prometheus Service is only able to scrape metrics from a cluster (EKS/ECS) Is that correct?**
-    We apologize for the lack of documentation for other compute environments. You can use Prometheus server to scrape [Prometheus metrics from EC2](https://aws.amazon.com/blogs/opensource/using-amazon-managed-service-for-prometheus-to-monitor-ec2-environments/) and any other compute environments where you can install a Prometheus server today as long as you configure the remote write and setup the [AWS SigV4 proxy](https://github.com/awslabs/aws-sigv4-proxy). The link to the [EC2 blog](https://aws.amazon.com/blogs/opensource/using-amazon-managed-service-for-prometheus-to-monitor-ec2-environments/) has a section “Running aws-sigv4-proxy” that can show you how to run it. We do need to add more documentation to help our customers simplify how to run AWS SigV4 on other compute environments.
-1. **How would one connect this service to Grafana? Is there some documentation about this?**
-    We use the default [Prometheus data source available in Grafana](https://grafana.com/docs/grafana/latest/datasources/prometheus/) to query Amazon Managed Service for Prometheus using PromQL. Here’s some documentation and a blog that will help you get started:
-    1. [Service docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-query.html)
-    1. [Grafana setup on EC2](https://aws.amazon.com/blogs/opensource/setting-up-grafana-on-ec2-to-query-metrics-from-amazon-managed-service-for-prometheus/)
-1. **What are some of the best practices to reduce the number of samples being sent to Amazon Managed Service for Prometheus?**
-    To reduce the number of samples being ingested into Amazon Managed Service for Prometheus, customers can extend their scrape interval (e.g., change from 30s to 1min) or decrease the number of series they are scraping. Changing the scrape interval will have a more dramatic impact on the number of samples than decreasing the number of series, with doubling the scrape interval halving the volume of samples ingested.
-1. **How to send CloudWatch metrics to Amazon Managed Service for Prometheus?**
-    We recommend utilizing [CloudWatch metric streams to send CloudWatch metrics to Amazon Managed Service for Prometheus](https://aws-observability.github.io/observability-best-practices/recipes/recipes/lambda-cw-metrics-go-amp/). Some possible shortcomings of this integration are,
-    1. A Lambda function is required to call the Amazon Managed Service for Prometheus APIs,
-    1. No ability to enrich CloudWatch metrics with metadata (e.g., with AWS tags) before ingesting them to Amazon Managed Service for Prometheus,
-    1. Metrics can only be filtered by namespace (not granular enough). As an alternative, customers can utilize Prometheus Exporters to send CloudWatch metrics data to Amazon Managed Service for Prometheus: (1) CloudWatch  Exporter: Java based scraping that uses CW ListMetrics and  GetMetricStatistics (GMS) APIs.
+## Which AWS Regions are supported currently and is it possible to collect metrics from other regions?
 
-    [**Yet Another CloudWatch Exporter (YACE)**](https://github.com/nerdswords/yet-another-cloudwatch-exporter) is another option to get metrics from CloudWatch into Amazon Managed Service for Prometheus. This is a Go based tool that uses the CW ListMetrics, GetMetricData (GMD), and  GetMetricStatistics (GMS) APIs. Some disadvantages in using this could be that you will have to deploy the agent and have to manage the life-cycle yourself which has to be done thoughtfully.
+See our [documentation](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html) for updated list of Regions that we support. Please let us know which regions you would like so that we can better prioritize our existing Product Feature Requests (PFRs). You can always collect data from any regions and send it to a specific region that we support. Here’s a blog for more details: [Cross-region metrics collection for Amazon Managed Service for Prometheus](https://aws.amazon.com/blogs/opensource/set-up-cross-region-metrics-collection-for-amazon-managed-service-for-prometheus-workspaces/).
 
-1. **What version of Prometheus are you compatible with?
-    **Amazon Managed Service for Prometheus is compatible with [Prometheus 2.x](https://github.com/prometheus/prometheus/blob/main/RELEASE.md). Amazon Managed Service for Prometheus is based on the open source [CNCF Cortex project](https://cortexmetrics.io/) as its data plane. Cortex strives to be 100% API compatible with Prometheus (under /prometheus/* and /api/prom/*). Amazon Managed Service for Prometheus supports Prometheus-compatible PromQL queries and Remote write metric ingestion and the Prometheus data model for existing metric types including Gauge, Counters, Summary, and Histogram. We do not currently expose [all Cortex APIs](https://cortexmetrics.io/docs/api/). The list of compatible APIs we support can be [found here](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-APIReference.html). Customers can work with their account team to open new or influence existing Product Features Requests (PFRs) if we are missing any features required from Amazon Managed Service for Prometheus.
-1. **What collector do you recommend for ingesting metrics into Amazon Managed Service for Prometheus? Should I utilize Prometheus in Agent mode?
-    **We support the usage of Prometheus servers inclusive of agent mode, the OpenTelemetry agent, and the AWS Distro for OpenTelemetry agent as agents that customers can use to send metrics data to Amazon Managed Service for Prometheus. The AWS Distro for OpenTelemetry is a downstream distribution of the OpenTelemetry project packaged and secured by AWS. Any of the three should be fine, and you’re welcome to pick whichever best suits your individual team’s needs and preferences.
-1. **How does Amazon Managed Service for Prometheus’s performance scale with the size of a workspace?**
-    Currently, Amazon Managed Service for Prometheus supports up to 200M active time series in a single workspace. When we announce a new max limit, we’re ensuring that the performance and reliability properties of the service continue to be maintained across ingest and query. Queries across the same size dataset should not see a performance degradation regardless of the number of active series in a workspace.
-1. **Product FAQ** [https://aws.amazon.com/prometheus/faqs/](.)
+## How long does it take to see metering and/or billing in Cost Explorer or [CloudWatch as AWS billing charges](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html)?
+
+We meter blocks of ingested metric samples as soon as they are uploaded to S3 every 2 hours. It can take up to 3 hours to see metering and charges reported for Amazon Managed Service for Prometheus.
+
+## Can the Prometheus Service only scrape metrics from a cluster (EKS/ECS)?
+
+We apologize for the lack of documentation for other compute environments. You can use Prometheus server to scrape [Prometheus metrics from EC2](https://aws.amazon.com/blogs/opensource/using-amazon-managed-service-for-prometheus-to-monitor-ec2-environments/) and any other compute environments where you can install a Prometheus server today as long as you configure the remote write and setup the [AWS SigV4 proxy](https://github.com/awslabs/aws-sigv4-proxy). The link to the [EC2 blog](https://aws.amazon.com/blogs/opensource/using-amazon-managed-service-for-prometheus-to-monitor-ec2-environments/) has a section “Running aws-sigv4-proxy” that can show you how to run it. We do need to add more documentation to help our customers simplify how to run AWS SigV4 on other compute environments.
+
+## How do you connect Amazon Managed Service for Prometheus to Grafana? Is there any documentation?
+
+We use the default [Prometheus data source available in Grafana](https://grafana.com/docs/grafana/latest/datasources/prometheus/) to query Amazon Managed Service for Prometheus using PromQL. Here’s some documentation and a blog that will help you get started:
+1. [Service docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-query.html)
+1. [Grafana setup on EC2](https://aws.amazon.com/blogs/opensource/setting-up-grafana-on-ec2-to-query-metrics-from-amazon-managed-service-for-prometheus/)
+
+## What are the best practices to reduce the number of samples being sent to Amazon Managed Service for Prometheus?
+
+To reduce the number of samples being ingested into Amazon Managed Service for Prometheus, customers can extend their scrape interval (e.g., change from 30s to 1min) or decrease the number of series they are scraping. Changing the scrape interval will have a more dramatic impact on the number of samples than decreasing the number of series, with doubling the scrape interval halving the volume of samples ingested.
+
+## How can I send CloudWatch metrics to Amazon Managed Service for Prometheus?
+
+We recommend utilizing [CloudWatch metric streams to send CloudWatch metrics to Amazon Managed Service for Prometheus](https://aws-observability.github.io/observability-best-practices/recipes/recipes/lambda-cw-metrics-go-amp/). Some possible shortcomings of this integration are,
+1. A Lambda function is required to call the Amazon Managed Service for Prometheus APIs,
+1. No ability to enrich CloudWatch metrics with metadata (e.g., with AWS tags) before ingesting them to Amazon Managed Service for Prometheus,
+1. Metrics can only be filtered by namespace (not granular enough). As an alternative, customers can utilize Prometheus Exporters to send CloudWatch metrics data to Amazon Managed Service for Prometheus: (1) CloudWatch  Exporter: Java based scraping that uses CW ListMetrics and  GetMetricStatistics (GMS) APIs.
+
+[**Yet Another CloudWatch Exporter (YACE)**](https://github.com/nerdswords/yet-another-cloudwatch-exporter) is another option to get metrics from CloudWatch into Amazon Managed Service for Prometheus. This is a Go based tool that uses the CW ListMetrics, GetMetricData (GMD), and  GetMetricStatistics (GMS) APIs. Some disadvantages in using this could be that you will have to deploy the agent and have to manage the life-cycle yourself which has to be done thoughtfully.
+
+## What version of Prometheus is Amazon Managed Service for Prometheus compatible with?
+
+Amazon Managed Service for Prometheus is compatible with [Prometheus 2.x](https://github.com/prometheus/prometheus/blob/main/RELEASE.md). Amazon Managed Service for Prometheus is based on the open source [CNCF Cortex project](https://cortexmetrics.io/) as its data plane. Cortex strives to be 100% API compatible with Prometheus (under /prometheus/* and /api/prom/*). Amazon Managed Service for Prometheus supports Prometheus-compatible PromQL queries and Remote write metric ingestion and the Prometheus data model for existing metric types including Gauge, Counters, Summary, and Histogram. We do not currently expose [all Cortex APIs](https://cortexmetrics.io/docs/api/). The list of compatible APIs we support can be [found here](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-APIReference.html). Customers can work with their account team to open new or influence existing Product Features Requests (PFRs) if we are missing any features required from Amazon Managed Service for Prometheus.
+
+## What collector do you recommend for ingesting metrics into Amazon Managed Service for Prometheus? Should I utilize Prometheus in Agent mode?
+
+We support the usage of Prometheus servers inclusive of agent mode, the OpenTelemetry agent, and the AWS Distro for OpenTelemetry agent as agents that customers can use to send metrics data to Amazon Managed Service for Prometheus. The AWS Distro for OpenTelemetry is a downstream distribution of the OpenTelemetry project packaged and secured by AWS. Any of the three should be fine, and you’re welcome to pick whichever best suits your individual team’s needs and preferences.
+
+## How does Amazon Managed Service for Prometheus’ performance scale with the size of a workspace?
+
+Currently, Amazon Managed Service for Prometheus supports up to 200M active time series in a single workspace. When we announce a new max limit, we’re ensuring that the performance and reliability properties of the service continue to be maintained across ingest and query. Queries across the same size dataset should not see a performance degradation regardless of the number of active series in a workspace.
+
+**Product FAQ:** [https://aws.amazon.com/prometheus/faqs/](https://aws.amazon.com/prometheus/faqs/)

--- a/docusaurus/docs/faq/cloudwatch.md
+++ b/docusaurus/docs/faq/cloudwatch.md
@@ -1,28 +1,28 @@
 # Amazon CloudWatch - FAQ
 
-**Why should I choose Amazon CloudWatch?**
+## Why should I choose Amazon CloudWatch?
 
 Amazon CloudWatch is an AWS cloud native service which provides unified observability on a single platform for monitoring AWS cloud resources and the applications you run on AWS. Amazon CloudWatch can be used to collect monitoring and operational data in the form of [logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html), track [metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html), [events](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/WhatIsCloudWatchEvents.html)and set [alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html). It also provides a [unified view](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html) of AWS resources, applications, and services that run on AWS and [on-premises servers](https://aws.amazon.com/blogs/mt/how-to-monitor-hybrid-environment-with-aws-services/). Amazon CloudWatch helps you gain system-wide visibility into resource utilization, application performance, and operational health of your workloads. Amazon CloudWatch provides [actionable insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Insights-Sections.html) for AWS, hybrid, and on-premises applications and infrastructure resources. [Cross-account observability](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) is an addition to CloudWatch’s unified observability capability.
 
-**Which AWS Services are natively integrated with Amazon CloudWatch and Amazon CloudWatch Logs?**
+## Which AWS Services are natively integrated with Amazon CloudWatch and Amazon CloudWatch Logs?
 
 Amazon CloudWatch natively integrates with more than 70+ AWS services allowing customers to collect infrastructure metrics for simplified monitoring and scalability with no action. Please check the documentation for a complete list of supported [AWS services that publish CloudWatch metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html). Currently, more than 30 AWS services publish logs to CloudWatch. Please check the documentation for a complete list of supported [AWS services that publish logs to CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/aws-services-sending-logs.html).
 
-**Where do I get the list of all the published metrics from all AWS Services to Amazon CloudWatch?**
+## Where do I get the list of all the published metrics from all AWS Services to Amazon CloudWatch?
 
 The list of all the [AWS Services that publish metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html) to Amazon CloudWatch is in AWS documentation.
 
-**Where do I get started for collecting & monitoring metrics to Amazon CloudWatch?**
+## Where do I get started for collecting & monitoring metrics to Amazon CloudWatch?
 
 [Amazon CloudWatch collects metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html) from various AWS Services which can be viewed through [AWS Management Console, AWS CLI, or an API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/viewing_metrics_with_cloudwatch.html). Amazon CloudWatch collects [available metrics](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html) for Amazon EC2 Instances. For additional custom metrics customers can make use of unified CloudWatch agent to collect and monitor.
 
 > Related AWS Observability Workshop: [Metrics](https://catalog.workshops.aws/observability/en-US/aws-native/metrics)
 
-**My Amazon EC2 Instance requires very granular level of monitoring, what do I do?**
+## My Amazon EC2 Instance requires very granular level of monitoring, what do I do?
 
 By default, Amazon EC2 sends metric data to CloudWatch in 5-minute periods as Basic Monitoring for an instance. To send metric data for your instance to CloudWatch in 1-minute periods, [detailed monitoring](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) can be enabled on the instance.
 
-**I want to publish own metrics for my application. Is there an option?**
+## I want to publish own metrics for my application. Is there an option?
 
 Customers can also publish their own [custom metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html) to CloudWatch using the API or CLI through standard resolution of 1 minute granularity or high resolution granularity down to 1 sec interval.
 
@@ -30,63 +30,63 @@ The CloudWatch agent also supports collecting custom metrics from EC2 instances 
 
 > Related AWS Observability Workshop: [Public custom metrics](https://catalog.workshops.aws/observability/en-US/aws-native/metrics/publishmetrics)
 
-**What more support is available for collecting custom metrics through Amazon CloudWatch agent?**
+## What more support is available for collecting custom metrics through Amazon CloudWatch agent?
 
 Custom metrics from applications or services can be retrieved using the unified CloudWatch agent with support for [StatsD](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-statsd.html)or [collectd](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-collectd.html)protocols. StatsD is a popular open-source solution that can gather metrics from a wide variety of applications. StatsD is especially useful for instrumenting own metrics, which supports both Linux and Windows based servers. collectd protocol is a popular open-source solution supported only on Linux Servers with plugins that can gather system statistics for a wide variety of applications.
 
-**My workload contains lot of ephemeral resources and generates logs in high-cardinality, what is the recommended approach collecting and measuring the metrics and logs?**
+## My workload contains lot of ephemeral resources and generates logs in high-cardinality, what is the recommended approach collecting and measuring the metrics and logs?
 
 [CloudWatch embedded metric format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html) enables customers to ingest complex high-cardinality application data in the form of logs and to generate actionable metrics from ephemeral resources such as Lambda functions and containers. By doing so, customers can embed custom metrics alongside detailed log event data without having to instrument or maintain separate code, while gaining powerful analytical capabilities on your log data and CloudWatch can automatically extract the custom metrics to help visualize the data and set alarm on them for real-time incident detection.
 
 > Related AWS Observability Workshop: [Embedded Metric Format](https://catalog.workshops.aws/observability/en-US/aws-native/metrics/emf)
 
-**Where do I get started for collecting & monitoring logs to Amazon CloudWatch?**
+## Where do I get started for collecting & monitoring logs to Amazon CloudWatch?
 
 [Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html) helps customers monitor and troubleshoot systems and applications in near real time using existing system, application and custom log files. Customers can install the [unified CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_GettingStarted.html) to collect [logs from Amazon EC2 Instances and on-premise servers](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html) to CloudWatch.
 
 > Related AWS Observability Workshop: [Log Insights](https://catalog.workshops.aws/observability/en-US/aws-native/logs/logsinsights)
 
-**What is CloudWatch agent and why should I use that?**
+## What is CloudWatch agent and why should I use that?
 
 The [Unified CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html) is an open-source software under the MIT license which supports most operating systems utilizing x86-64 and ARM64 architectures. The CloudWatch Agent helps collect system-level metrics from Amazon EC2 Instances & on-premise servers in a hybrid environment across operating systems, retrieve custom metrics from applications or services and collect logs from Amazon EC2 instances and on-premises servers.
 
-**I’ve all scales of installation required in my environment, so how can the CloudWatch agent be installed normally and using automation?**
+## I’ve all scales of installation required in my environment, so how can the CloudWatch agent be installed normally and using automation?
 
 On all the supported operating systems including Linux and Windows Servers, customers can download and [install the CloudWatch agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-on-EC2-Instance.html) using the [command line](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/installing-cloudwatch-agent-commandline.html), using AWS [Systems Manager](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/installing-cloudwatch-agent-ssm.html), or using an AWS [CloudFormation template](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent-New-Instances-CloudFormation.html). You can also install the [CloudWatch agent on on-premise servers](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-on-premise.html) for monitoring.
 
-**We have multiple AWS accounts in multiple regions in our Organization, does Amazon CloudWatch work for these scenarios.**
+## We have multiple AWS accounts in multiple regions in our Organization, does Amazon CloudWatch work for these scenarios?
 
 Amazon CloudWatch provides [cross-account observability](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)which helps customers monitor and troubleshoot health of resources and applications that span multiple accounts within a region. Amazon CloudWatch also provides a [cross-account, cross-region dashboard](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html). With this functionality customers can gain visibility and insights of their multi-account, multi-region resources and workloads.
 
-**What kind of automation support is available for Amazon CloudWatch?**
+## What kind of automation support is available for Amazon CloudWatch?
 
 Apart from accessing Amazon CloudWatch through the AWS Management Console customers can also access the service via API, [AWS command-line interface (CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and [AWS SDKs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/sdk-general-information-section.html). [CloudWatch API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/Welcome.html) for metrics & dashboards help in automating through [AWS CLI](https://docs.aws.amazon.com/AmazonCloudWatch/latest/cli/Welcome.html)or integrating with software/products so that you can spend less time managing or administering the resources and applications. [CloudWatch API](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/Welcome.html) for logs along with [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/logs/index.html) are also available separately. [Code examples for CloudWatch using AWS SDKs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/service_code_examples.html) are available for customers for additional reference.
 
-**I want to get started with monitoring resources quickly, what is the recommended approach?**
+## I want to get started with monitoring resources quickly, what is the recommended approach?
 
 Automatic Dashboards in CloudWatch are available in all AWS public regions which provides an aggregated view of the health and performance of all AWS resources. This helps customers quickly get started with monitoring, resource-based view of metrics and alarms, and easily drill-down to understand the root cause of performance issues. [Automatic Dashboards](https://docs.aws.amazon.com/prescriptive-guidance/latest/implementing-logging-monitoring-cloudwatch/cloudwatch-dashboards-visualizations.html) are pre-built with AWS service recommended best practices, remain resource aware, and dynamically update to reflect the latest state of important performance metrics.
 
 Related AWS Observability Workshop: [Automatic Dashboards](https://catalog.workshops.aws/observability/en-US/aws-native/dashboards/autogen-dashboard)
 
-**I want to customize what I want to monitor in CloudWatch, what is the recommended approach?**
+## I want to customize what I want to monitor in CloudWatch, what is the recommended approach?
 
 With [Custom Dashboard](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create_dashboard.html) customers can create as many additional dashboards as they want with different widgets and customize it accordingly. When creating a custom dashboard, there are a variety of widget types that are available to pick and choose for customization.
 
 Related AWS Observability Workshop: [Dashboarding](https://catalog.workshops.aws/observability/en-US/aws-native/ec2-monitoring/dashboarding)
 
-**I’ve built few custom dashboards , is there a way to share it?**
+## I’ve built few custom dashboards , is there a way to share it?
 
 Yes, [sharing of CloudWatch dashboards](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-dashboard-sharing.html) is possible. There are three ways to share. Sharing a single dashboard publicly by allowing anyone with access to the link to view the dashboard. Sharing a single dashboard privately by specifying the email addresses of the people who are allowed to view the dashboard. Sharing all of the CloudWatch dashboards in the account by specifying a third-party single sign-on (SSO) provider for dashboard access.
 
 > Related AWS Observability Workshop: [Sharing CloudWatch Dashboards](https://catalog.workshops.aws/observability/en-US/aws-native/dashboards/sharingdashboard)
 
-**I want to improve the observability of my application including the aws resources underneath, how can I accomplish?**
+## I want to improve the observability of my application including the aws resources underneath, how can I accomplish?
 
 [Amazon CloudWatch Application Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-application-insights.html) facilitates observability for your applications along with the underlying AWS resources like SQL Server database, .Net based web (IIS) stack, application servers, OS, load balancers, queues, etc. It helps customers identify and set up key metrics and logs across application resources & technology stack. By doing so, it reduces mean time to repair (MTTR) & troubleshoot application issues faster.
 
 > Additional details in FAQ: [AWS resource & custom metrics monitoring](https://aws.amazon.com/cloudwatch/faqs/#AWS_resource_.26_custom_metrics_monitoring)
 
-**My Organization is open-source centric, does Amazon CloudWatch support monitoring & observability through open-source technologies.**
+## My Organization is open-source centric, does Amazon CloudWatch support monitoring & observability through open-source technologies?
 
 For collecting metrics and traces, [AWS Distro for OpenTelemetry (ADOT) Collector](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-open-telemetry.html) along with the CloudWatch agent can be installed side-by-side on Amazon EC2 Instance and OpenTelemetry SDKs can be used to collect application traces & metrics from your workloads running on Amazon EC2 Instances.
 
@@ -96,7 +96,7 @@ For logs, Fluent Bit helps create an easy extension point for streaming [logs fr
 
 For Dashboards, Amazon Managed Grafana can be added with [Amazon CloudWatch as a data source](https://docs.aws.amazon.com/grafana/latest/userguide/using-amazon-cloudwatch-in-AMG.html) by using the AWS data source configuration option in the Grafana workspace console. This feature simplifies adding CloudWatch as a data source by discovering existing CloudWatch accounts and manage the configuration of the authentication credentials that are required to access CloudWatch.
 
-**Our workload is already built to collect metrics using Prometheus from the environment. Can I continue using the same methodology.**
+## Our workload is already built to collect metrics using Prometheus from the environment. Can I continue using the same methodology?
 
 Customers can choose to have an all open-source setup for their observability needs. For which, AWS Distro for OpenTelemetry (ADOT) Collector can be configured to scrape from a Prometheus-instrumented application and send the metrics to Prometheus Server or Amazon Managed Prometheus.
 
@@ -104,33 +104,33 @@ The CloudWatch agent on EC2 instances can be installed & configured with [Promet
 
 CloudWatch [Container Insights monitoring for Prometheus](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus.html) automates the discovery of Prometheus metrics from containerized systems and workloads. Discovering Prometheus metrics is supported for Amazon Elastic Container Service (ECS), Amazon Elastic Kubernetes Service (EKS) and Kubernetes clusters running on Amazon EC2 instances.
 
-**My workloads contain microservices compute, especially EKS/Kubernetes related containers, how do I use Amazon CloudWatch to gain insights into the environment?**
+## My workloads contain microservices compute, especially EKS/Kubernetes related containers, how do I use Amazon CloudWatch to gain insights into the environment?
 
 Customers can use [CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html) to collect, aggregate, and summarize metrics & logs from containerized applications and microservices running on [Amazon Elastic Kubernetes Service (Amazon EKS)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-EKS.html) or Kubernetes platforms on Amazon EC2. [Container Insights](https://aws.amazon.com/cloudwatch/faqs/#Container_Monitoring) also supports collecting metrics from clusters deployed on Fargate for Amazon EKS. CloudWatch automatically [collects metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-metrics.html) for many resources, such as CPU, memory, disk & network and also [provides diagnostic information](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference.html), such as container restart failures, to help isolate issues and resolve them quickly.
 
 > Related AWS Observability Workshop: [Container Insights on EKS](https://catalog.workshops.aws/observability/en-US/aws-native/insights/containerinsights/eks)
 
-**My workloads contain microservices compute, especially ECS related containers, how do I use Amazon CloudWatch to gain insights into the environment?**
+## My workloads contain microservices compute, especially ECS related containers, how do I use Amazon CloudWatch to gain insights into the environment?
 
 Customers can use [CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html) to collect, aggregate, and summarize metrics & logs from containerized applications and microservices running on [Amazon Elastic Container Service (Amazon ECS)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS.html) or container platforms on Amazon EC2. [Container Insights](https://aws.amazon.com/cloudwatch/faqs/#Container_Monitoring) also supports collecting metrics from clusters deployed on Fargate for Amazon ECS. CloudWatch automatically [collects metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-metrics.html) for many resources, such as CPU, memory, disk & network and also [provides diagnostic information](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-reference.html), such as container restart failures, to help isolate issues and resolve them quickly.
 
 > Related AWS Observability Workshop: [Container Insights on ECS](https://catalog.workshops.aws/observability/en-US/aws-native/insights/containerinsights/ecs)
 
-**My workloads contain serverless compute, especially AWS Lambda, how do I use Amazon CloudWatch to gain insights into the environment?**
+## My workloads contain serverless compute, especially AWS Lambda, how do I use Amazon CloudWatch to gain insights into the environment?
 
 Customers can use [CloudWatch Lambda Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights.html) for monitoring and troubleshooting serverless applications running on AWS Lambda. [CloudWatch Lambda Insights](https://aws.amazon.com/cloudwatch/faqs/#Lambda_Monitoring) collects, aggregates, and summarizes system-level metrics including CPU time, memory, disk, and network & also collects, aggregates, and summarizes diagnostic information such as cold starts and Lambda worker shutdowns to help customers isolate issues with Lambda functions and resolve them quickly.
 
 > Related AWS Observability Workshop: [Lambda Insights](https://catalog.workshops.aws/observability/en-US/aws-native/insights/lambdainsights)
 
-**I aggregate lot of logs into Amazon CloudWatch logs, how do I gain observability into those data?**
+## I aggregate lot of logs into Amazon CloudWatch logs, how do I gain observability into those data?
 
 [CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) enables customers to interactively search, analyze log data and have customers perform queries to efficiently and effectively respond to operational issues in Amazon CloudWatch Logs. If an issue occurs, customers can use [CloudWatch Logs Insights](https://aws.amazon.com/cloudwatch/faqs/#Log_analytics) to identify potential causes and validate deployed fixes.
 
-**How do I query logs in Amazon CloudWatch Logs?**
+## How do I query logs in Amazon CloudWatch Logs?
 
 CloudWatch Logs Insights in Amazon CloudWatch Logs use a [query language](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html) to query log groups.
 
-**How do I manage logs stored in Amazon CloudWatch Logs for cost optimization, compliance retention or for additional processing?**
+## How do I manage logs stored in Amazon CloudWatch Logs for cost optimization, compliance retention or for additional processing?
 
 By default, [LogGroups](https://aws.amazon.com/cloudwatch/faqs/#Log_management)Amazon CloudWatch Logs are[kept indefinitely and never expire](https://docs.aws.amazon.com/managedservices/latest/userguide/log-customize-retention.html). Customers can adjust the retention policy of each log group to choose a retention period between one day and 10 years, depending up on how long they want to retain the logs to optimize cost or for compliance purposes.
 
@@ -138,45 +138,45 @@ Customers can export log data from [log groups to Amazon S3 bucket](https://docs
 
 Customers can also configure log groups in CloudWatch Logs to [stream data to your Amazon OpenSearch Service](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_OpenSearch_Stream.html) cluster in near real-time through a CloudWatch Logs subscription. By doing so, it helps customers to perform interactive log analytics, real-time application monitoring, search, and more.
 
-**My workloads generate logs which could have sensitive data, is there a way to protect them in Amazon CloudWatch?**
+## My workloads generate logs which could have sensitive data, is there a way to protect them in Amazon CloudWatch?
 
 Customers can make use of [Log data protection feature](https://aws.amazon.com/cloudwatch/faqs/#Log_data_protection) in CloudWatch Logs that helps customers [define own rules and policies to automatically](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html#mask-sensitive-log-data-start) detect and mask sensitive data within logs that are collected from systems and applications.
 
 Related AWS Observability Workshop: [Data Protection](https://catalog.workshops.aws/observability/en-US/aws-native/logs/dataprotection)
 
-**I would like to know anomaly bands or unexpected changes when it happens to my systems & applications. How can Amazon CloudWatch alert me when it occurs.**
+## I would like to know anomaly bands or unexpected changes when it happens to my systems & applications. How can Amazon CloudWatch alert me when it occurs?
 
 [Amazon CloudWatch Anomaly Detection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html) applies statistical and machine learning algorithms to continuously analyze single time series of systems and applications, determine normal baselines, and surface anomalies with minimal user intervention. The algorithms create an anomaly detection model that generates a range of expected values that represent normal metric behavior. Customers can [create alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Anomaly_Detection_Alarm.html) based on the analysis of past metric data and a value set for the anomaly threshold.
 
 > Related AWS Observability Workshop: [Anomaly Detection](https://catalog.workshops.aws/observability/en-US/aws-native/metrics/alarms/anomalydetection)
 
-**I’ve setup metric alarm in Amazon CloudWatch, however I’m getting frequent alarm noises. How can I control and fine tune this?**
+## I’ve setup metric alarm in Amazon CloudWatch, however I’m getting frequent alarm noises. How can I control and fine tune this?
 
 Customers can combine multiple alarms into alarm hierarchies as [composite alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html) to reduce alarm noise by triggering just once when multiple [alarms](https://aws.amazon.com/cloudwatch/faqs/#Alarms) fire simultaneously. Composite alarms support an overall state by helping customers in grouping resources like an application, AWS Region, or AZ.
 
 > Related AWS Observability Workshop: [Alarms](https://catalog.workshops.aws/observability/en-US/aws-native/metrics/alarms)
 
-**My workload facing the internet is experiencing performance and availability issues, how do I troubleshoot?**
+## My workload facing the internet is experiencing performance and availability issues, how do I troubleshoot?
 
 [Amazon CloudWatch Internet Monitor](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-InternetMonitor.html) provides visibility into how internet issues impact the performance and availability between your applications hosted on AWS and your end users. With [Internet Monitor](https://aws.amazon.com/cloudwatch/faqs/#Internet_Monitoring), you can quickly identify what's impacting your application's performance and availability, so that you can track down and address issues which can significantly reduce the time it takes to diagnose internet issues.
 
-**I've my workload on AWS and I want to get notified even before the end users experience an impact or latency in accessing the application. How do I get better visibility and improve the observability of my customer facing workload?**
+## I've my workload on AWS and I want to get notified even before the end users experience an impact or latency in accessing the application. How do I get better visibility and improve the observability of my customer facing workload?
 
 Customers can use [Amazon CloudWatch Synthetics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html) to create canaries, configurable scripts that run on a schedule, to monitor your endpoints and APIs. Canaries follow the same routes and perform the same actions as a customer, which makes it possible to continually verify end user experience even when there are no live traffic to your applications. Canaries help you discover issues even before your customers do. Canaries check the availability and latency of endpoints and can store load time data and screenshots of the UI as rendered by a headless Chromium browser.
 
 > Related AWS Observability Workshop: [CloudWatch Synthetics](https://catalog.workshops.aws/observability/en-US/aws-native/app-monitoring/synthetics)
 
-**I've my workload on AWS and I want to observe end user experience by identifying client-side performance issues and action a faster resolution if there are any real-time issues.**
+## How can I observe end user experience by identifying client-side performance and resolve real-time issues?
 
 [CloudWatch RUM](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM.html) can perform real user monitoring to collect and view client-side data about your web application performance from actual user sessions in near real time. This collected data helps quickly identify and debug client-side performance issues and also helps to visualize and analyze page load times, client-side errors, and user behavior. When viewing this data, customers can see it all aggregated together and also see breakdowns by the browsers and devices that your customers use. CloudWatch RUM helps visualize anomalies in your application performance and find relevant debugging data such as error messages, stack traces, and user sessions.
 
 > Related AWS Observability Workshop: [CloudWatch RUM](https://catalog.workshops.aws/observability/en-US/aws-native/app-monitoring/rum)
 
-**My Organization requires all actions be recorded for audits. Can Amazon CloudWatch events be recorded?**
+## My Organization requires all actions be recorded for audits. Can Amazon CloudWatch events be recorded?
 
 Amazon CloudWatch is integrated with [AWS CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html), which provides a record of actions taken by a user, a role, or an AWS service in Amazon CloudWatch. CloudTrail captures all [API calls for Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/logging_cw_api_calls.html) as events that include calls from the console and code calls to API operations.
 
-**What more information is available?**
+## What more information is available?
 
 For additional information customers can read the AWS Documentation for [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html), [CloudWatch Events](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/WhatIsCloudWatchEvents.html) and [CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html), go through the AWS Observability Workshop on [AWS Native Observability](https://catalog.workshops.aws/observability/en-US/aws-native) and also check the [product page](https://aws.amazon.com/cloudwatch/) to know the [features](https://aws.amazon.com/cloudwatch/features/), and [pricing](https://aws.amazon.com/cloudwatch/pricing/) details. Additional [tutorials on CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-tutorials.html) illustrating customer use case scenarios.
 

--- a/docusaurus/docs/faq/x-ray.md
+++ b/docusaurus/docs/faq/x-ray.md
@@ -1,21 +1,36 @@
 # AWS X-Ray - FAQ
 
-1. **Does AWS Distro for Open Telemetry (ADOT) support trace propagation across AWS services such as Event Bridge or SQS?
-    **Technically, that’s not ADOT but AWS X-Ray. We are working on expanding the number and types of AWS services that propagate and/or generate spans. If you have a use case depending on this, please reach out to us.
-1. **Will I be able to use the W3C trace header to ingest spans into AWS X-Ray using ADOT?**
-    Yes, later in 2023. We’re working on supporting W3C trace context propagation. 
-1. Can I trace requests across Lambda functions when SQS is involved in the middle?
-    Yes. X-Ray now supports tracing across Lambda functions when SQS is involved in the middle. Traces from upstream message producers are [automatically linked to traces](https://docs.aws.amazon.com/xray/latest/devguide/xray-services-sqs.html) from downstream Lambda consumer nodes, creating an end-to-end view of the application.
-1. **Should I use X-Ray SDK or the OTel SDK to instrument my application?**
-    OTel offers more features than the X-Ray SDK, but to choose which one is right for your use case see [Choosing between ADOT and X-Ray SDK](https://docs.aws.amazon.com/xray/latest/devguide/xray-instrumenting-your-app.html#xray-instrumenting-choosing)
-1. **Are [span events](https://opentelemetry.io/docs/instrumentation/ruby/manual/#add-span-events) supported in AWS X-Ray?**
- Span events do not fit into the X-Ray model and are hence dropped.
-1. **How can I extract data out of AWS X-Ray?**
- You can retrieve Service Graph, Traces and Root cause analytics data [using X-Ray APIs](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-gettingdata.html).
-1. **Can I achieve 100% sampling? That is, I want all traces to be recorded without sampling at all.**
- You can adjust the sampling rules to capture significantly increased amount of trace data. As long as the total segments sent do not breach the [service quota limits mentioned here](https://docs.aws.amazon.com/general/latest/gr/xray.html#limits_xray), X-Ray will make an effort to collect data as configured. There is no guarantee that this will result in 100% trace data capture as a result.
-1. **Can I dynamically increase or decrease sampling rules through APIs?**
+## Does AWS Distro for Open Telemetry (ADOT) support trace propagation across AWS services such as Event Bridge or SQS?
+
+Technically, that’s not ADOT but AWS X-Ray. We are working on expanding the number and types of AWS services that propagate and/or generate spans. If you have a use case depending on this, please reach out to us.
+
+## Will I be able to use the W3C trace header to ingest spans into AWS X-Ray using ADOT?
+
+Yes. [W3c trace header](https://aws.amazon.com/about-aws/whats-new/2023/10/aws-x-ray-w3c-format-trace-ids-distributed-tracing/) was released on Oct 27th 2023.
+
+## Can I trace requests across Lambda functions when SQS is involved in the middle?
+
+Yes. X-Ray now supports tracing across Lambda functions when SQS is involved in the middle. Traces from upstream message producers are [automatically linked to traces](https://docs.aws.amazon.com/xray/latest/devguide/xray-services-sqs.html) from downstream Lambda consumer nodes, creating an end-to-end view of the application.
+
+## Should I use X-Ray SDK or the OTel SDK to instrument my application?
+
+OTel offers more features than the X-Ray SDK, but to choose which one is right for your use case see [Choosing between ADOT and X-Ray SDK](https://docs.aws.amazon.com/xray/latest/devguide/xray-instrumenting-your-app.html#xray-instrumenting-choosing)
+
+##  Are [span events](https://opentelemetry.io/docs/instrumentation/ruby/manual/#add-span-events) supported in AWS X-Ray?
+
+Span events do not fit into the X-Ray model and are hence dropped.
+
+## How can I extract data out of AWS X-Ray?
+
+You can retrieve Service Graph, Traces and Root cause analytics data [using X-Ray APIs](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-gettingdata.html).
+
+## Can I achieve 100% sampling? That is, I want all traces to be recorded without sampling at all.
+
+You can adjust the sampling rules to capture significantly increased amount of trace data. As long as the total segments sent do not breach the [service quota limits mentioned here](https://docs.aws.amazon.com/general/latest/gr/xray.html#limits_xray), X-Ray will make an effort to collect data as configured. There is no guarantee that this will result in 100% trace data capture as a result.
+
+## Can I dynamically increase or decrease sampling rules through APIs?
+
 Yes, you can use the [X-Ray sampling APIs](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sampling.html) to make adjustments dynamically as necessary. See this [blog for a use-case based explanation](https://aws.amazon.com/blogs/mt/dynamically-adjusting-x-ray-sampling-rules/).
-1. **Product FAQ**
-[https://aws.amazon.com/xray/faqs/](.)
+
+**Product FAQ:** [https://aws.amazon.com/xray/faqs/](https://aws.amazon.com/xray/faqs/)
 


### PR DESCRIPTION
…faq section and not the ./docusaurus/docs/faq. I have copied my updates to that section so they will be reflected in the public facing site

*Issue #, if available:*

*Description of changes:*
I copied my FAQ updates that were located in ./docs/en/faq to ./docusaurus/docs/faq so they will be reflected on the public site. I wasn't aware that there were two locations for the FAQs and that docusaurus is the active public page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

