### PR TITLE
Fixes the recipie link for AMG subnet monitoring

### DIFF
--- a/docs/en/contributors.md
+++ b/docs/en/contributors.md
@@ -16,6 +16,7 @@ people:
 | Kiran Prakash       | Bobby Hallahan              | Toshal Dudhwala   | Franklin Aguinaldo |
 | Nirmal Mehta        | Lucas Vieira Souza da Silva | William Armiros   | Abhi Khanna        |
 | Arvind Raghunathan  | Doyita Mitra                | Rahul Popat       | Taiki Hibira       |
+| Ashish Ranjan       |                             |                   |                    |
 
 
 Note that all recipes published on this site are available via the

--- a/docs/en/recipes/amg.md
+++ b/docs/en/recipes/amg.md
@@ -34,6 +34,7 @@ Check out the following recipes:
 - [Managing Grafana and Loki in a regulated multitenant environment][grafana-loki-regenv]
 - [Monitoring Amazon EKS Anywhere using Amazon Managed Service for Prometheus and Amazon Managed Grafana][amg-anywhere-monitoring]
 - [Workshop for Getting Started][amg-oow]
+- [Monitoring free IP in Subnet][amg-subnet-free-ip-monitoring]
 
 
 [amg-main]: https://aws.amazon.com/grafana/
@@ -52,4 +53,4 @@ Check out the following recipes:
 [amg-anywhere-monitoring]: https://aws.amazon.com/blogs/containers/monitoring-amazon-eks-anywhere-using-amazon-managed-service-for-prometheus-and-amazon-managed-grafana/
 [amg-amp-statsd]: https://aws.amazon.com/blogs/mt/viewing-custom-metrics-from-statsd-with-amazon-managed-service-for-prometheus-and-amazon-managed-grafana/
 [amg-grafana-teams]: https://aws.amazon.com/blogs/mt/fine-grained-access-control-in-amazon-managed-grafana-using-grafana-teams/
-
+[amg-subnet-free-ip-monitoring]: https://aws-observability.github.io/observability-best-practices/recipes/recipes/amg-subnet-free-ip-monitoring/

--- a/docs/en/recipes/recipes/amg-subnet-free-ip-monitoring.md
+++ b/docs/en/recipes/recipes/amg-subnet-free-ip-monitoring.md
@@ -1,4 +1,4 @@
-# Monitoring Free IP in customers subnet
+# Monitoring Free IP in Subnet
 
 In this recipe we show you how to setup monitoring stack to monitor for available IPs in the subnet.
 

--- a/docs/ja/contributors.md
+++ b/docs/ja/contributors.md
@@ -15,6 +15,7 @@
 | Kiran Prakash       | Bobby Hallahan              | Toshal Dudhwala   | Franklin Aguinaldo |
 | Nirmal Mehta        | Lucas Vieira Souza da Silva | William Armiros   | Abhi Khanna        |
 | Arvind Raghunathan  | Doyita Mitra                | Rahul Popat       | Taiki Hibira       |
+| Ashish Ranjan       |                             |                   |                    |
 
 
 このサイトで公開されているすべてのレシピは、次のURLから入手できることに注意してください。

--- a/sandbox/grafana_subnet_ip_monitoring/README.md
+++ b/sandbox/grafana_subnet_ip_monitoring/README.md
@@ -28,4 +28,4 @@ The logs for the lambda can be found in the Cloudwatch log group `/aws/lambda/Vp
  * `cdk diff`        compare deployed stack with current state
  * `cdk synth`       emits the synthesized CloudFormation template
 
- [Link to Recipe](https://aws-observability.github.io/observability-best-practices/recipes/recipes/subnet-free-ip-monitoring/)
+ [Link to Recipe](https://aws-observability.github.io/observability-best-practices/recipes/recipes/amg-subnet-free-ip-monitoring/)


### PR DESCRIPTION
This commit fixes the recipie for subnet monitoring.


