### PR TITLE
feat(docs): add floating banner component for cloudops events

### DIFF
--- a/docusaurus/src/components/FloatingBanner.js
+++ b/docusaurus/src/components/FloatingBanner.js
@@ -1,0 +1,64 @@
+import React, {useState} from 'react';
+
+const bannerStyle = {
+  position: 'fixed',
+  top: '60px',
+  right: '16px',
+  zIndex: 100,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  backgroundColor: '#232f3e',
+  color: '#ffffff',
+  fontSize: '0.8rem',
+  padding: '5px 12px',
+  borderRadius: '4px',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+  whiteSpace: 'nowrap',
+};
+
+const linkStyle = {
+  color: '#ff9900',
+  fontWeight: 700,
+  textDecoration: 'none',
+};
+
+const closeStyle = {
+  color: '#999',
+  cursor: 'pointer',
+  marginLeft: '8px',
+  fontSize: '1rem',
+  lineHeight: 1,
+  background: 'none',
+  border: 'none',
+  padding: 0,
+};
+
+export default function FloatingBanner() {
+  const [visible, setVisible] = useState(true);
+
+  if (!visible) return null;
+
+  return (
+    <div style={bannerStyle}>
+      <span>Live:</span>
+      <span>CloudOps Webinars &amp; Hands-on Workshops ·</span>
+      <a
+        href="https://aws-experience.com/amer/smb/events/series/Cloud-Operations-Enablement"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={linkStyle}
+      >
+        Register ↗
+      </a>
+      <button
+        onClick={() => setVisible(false)}
+        style={closeStyle}
+        aria-label="Close banner"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -66,3 +66,4 @@
   border: 1px solid var(--ifm-color-emphasis-300);
   background: var(--ifm-color-emphasis-100);
 }
+

--- a/docusaurus/src/theme/Root.js
+++ b/docusaurus/src/theme/Root.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import FloatingBanner from '@site/src/components/FloatingBanner';
+
+export default function Root({children}) {
+  return (
+    <>
+      <FloatingBanner />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Create FloatingBanner component with dismissible UI for CloudOps event promotion
- Add Root theme wrapper to inject FloatingBanner globally across documentation
- Style banner with fixed positioning, AWS branding colors, and accessibility features
- Include close button functionality to allow users to dismiss the banner


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

