### PR TITLE
fix(components): update CloudOps webinar link with tracking parameters

### DIFF
--- a/docusaurus/src/components/FloatingBanner.js
+++ b/docusaurus/src/components/FloatingBanner.js
@@ -45,7 +45,7 @@ export default function FloatingBanner() {
       <span>Live:</span>
       <span>CloudOps Webinars &amp; Hands-on Workshops ·</span>
       <a
-        href="https://aws-experience.com/amer/smb/events/series/Cloud-Operations-Enablement"
+        href="https://aws-experience.com/amer/smb/events/series/Cloud-Operations-Enablement?trk=d12ac22e-c3d0-4081-9e94-e2f911079e70&sc_channel=el"
         target="_blank"
         rel="noopener noreferrer"
         style={linkStyle}


### PR DESCRIPTION
*Description of changes:*
- Add tracking parameters to CloudOps Webinars event URL
- Include campaign ID and channel source in href attribute
- Improve event link attribution and analytics tracking

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

