### PR TITLE
sandbox: add OTel gateway pipeline monitoring deployment

### DIFF
--- a/sandbox/otel-gateway-deployment/README.md
+++ b/sandbox/otel-gateway-deployment/README.md
@@ -16,6 +16,7 @@ infrastructure Container Insights.
 | `agent.yaml` | Self-managed OTel Collector **agent** (DaemonSet): OTLP receiver → `memory_limiter` + `k8sattributes` + `batch` → forwards to the gateway. Includes ServiceAccount, k8sattributes RBAC, and Service. |
 | `gateway.yaml` | OTel Collector **gateway** (Deployment ×2 + Service): OTLP + Prometheus self-scrape receivers → `memory_limiter` + `batch` → `otlphttp` (`metrics_endpoint` + `sigv4auth`) to CloudWatch; `health_check` on :13133; self-telemetry on :8888. Contains an `<ACCOUNT_ID>` placeholder. |
 | `dashboard.json` | CloudWatch dashboard body (`OTel-Gateway-Pipeline-Health`) — throughput, export success vs failure, queue utilization, refused metrics. Uses PromQL `chart` widgets. |
+| `networkpolicy.yaml` | Two Kubernetes **NetworkPolicies** restricting OTLP ingress: the gateway accepts 4317/4318 only from the `otel-agent` namespace, and the agent only from your application namespaces; health/metrics ports (13133/8888) stay open for probes and scraping. Enforcement requires the VPC CNI network policy controller. |
 
 ## Prerequisites
 
@@ -41,6 +42,11 @@ curl -sSL https://raw.githubusercontent.com/aws-observability/observability-best
 
 # 2) Agent tier (no placeholders)
 kubectl apply -f https://raw.githubusercontent.com/aws-observability/observability-best-practices/main/sandbox/otel-gateway-deployment/agent.yaml
+
+# 2b) (Optional) Restrict OTLP ingress with NetworkPolicies. Edit the application
+#     namespace selector in the file to match your workload namespaces first.
+#     Enforcement requires the VPC CNI network policy controller (on by default in EKS Auto Mode).
+kubectl apply -f https://raw.githubusercontent.com/aws-observability/observability-best-practices/main/sandbox/otel-gateway-deployment/networkpolicy.yaml
 
 # 3) Point your workloads at the node-local agent (SDK env vars)
 #    OTEL_EXPORTER_OTLP_ENDPOINT = http://$(NODE_IP):4317   (NODE_IP from downward API status.hostIP)

--- a/sandbox/otel-gateway-deployment/README.md
+++ b/sandbox/otel-gateway-deployment/README.md
@@ -21,7 +21,7 @@ infrastructure Container Insights.
 
 ## Prerequisites
 
-- Amazon EKS cluster running Kubernetes 1.28 or later.
+- Amazon EKS cluster running Kubernetes 1.31 or later.
 - OIDC provider configured for IAM Roles for Service Accounts (IRSA).
 - An IAM role `OTelGatewayRole` for the gateway ServiceAccount with `CloudWatchAgentServerPolicy`
   attached (trust policy scoped to `system:serviceaccount:otel-gateway:otel-gateway`).

--- a/sandbox/otel-gateway-deployment/README.md
+++ b/sandbox/otel-gateway-deployment/README.md
@@ -1,0 +1,80 @@
+# OpenTelemetry Gateway on Amazon EKS — Monitoring Your Observability Pipeline
+
+Companion manifests for the AWS blog **"Deploy OpenTelemetry Gateway on AWS: Monitoring
+Your Observability Pipeline."** They deploy an agent-to-gateway OpenTelemetry pipeline on
+Amazon EKS that exports metrics to Amazon CloudWatch via the native OTLP endpoint (SigV4)
+and self-monitors the gateway ("monitor the monitoring").
+
+Pattern: **application → node-local OTel agent (DaemonSet) → OTel gateway (Deployment) →
+CloudWatch native OTLP**. The CloudWatch Observability EKS add-on runs alongside for
+infrastructure Container Insights.
+
+## Files
+
+| File | What it is |
+|------|------------|
+| `agent.yaml` | Self-managed OTel Collector **agent** (DaemonSet): OTLP receiver → `memory_limiter` + `k8sattributes` + `batch` → forwards to the gateway. Includes ServiceAccount, k8sattributes RBAC, and Service. |
+| `gateway.yaml` | OTel Collector **gateway** (Deployment ×2 + Service): OTLP + Prometheus self-scrape receivers → `memory_limiter` + `batch` → `otlphttp` (`metrics_endpoint` + `sigv4auth`) to CloudWatch; `health_check` on :13133; self-telemetry on :8888. Contains an `<ACCOUNT_ID>` placeholder. |
+| `dashboard.json` | CloudWatch dashboard body (`OTel-Gateway-Pipeline-Health`) — throughput, export success vs failure, queue utilization, refused metrics. Uses PromQL `chart` widgets. |
+
+## Prerequisites
+
+- Amazon EKS cluster running Kubernetes 1.28 or later.
+- OIDC provider configured for IAM Roles for Service Accounts (IRSA).
+- An IAM role `OTelGatewayRole` for the gateway ServiceAccount with `CloudWatchAgentServerPolicy`
+  attached (trust policy scoped to `system:serviceaccount:otel-gateway:otel-gateway`).
+- The CloudWatch Observability EKS add-on installed (its service account also needs
+  `CloudWatchAgentServerPolicy` via IRSA or EKS Pod Identity).
+- Network egress from the cluster to the CloudWatch OTLP endpoint
+  (`monitoring.<region>.amazonaws.com`, HTTPS/443) — via NAT or a CloudWatch VPC interface endpoint.
+
+## Deploy
+
+> Review these manifests before applying. Pin to a release tag/commit rather than `main`
+> so your steps stay reproducible.
+
+```bash
+# 1) Gateway (substitute your AWS account ID for the IRSA annotation)
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+curl -sSL https://raw.githubusercontent.com/aws-observability/observability-best-practices/main/sandbox/otel-gateway-deployment/gateway.yaml \
+  | sed "s/<ACCOUNT_ID>/$ACCOUNT_ID/g" | kubectl apply -f -
+
+# 2) Agent tier (no placeholders)
+kubectl apply -f https://raw.githubusercontent.com/aws-observability/observability-best-practices/main/sandbox/otel-gateway-deployment/agent.yaml
+
+# 3) Point your workloads at the node-local agent (SDK env vars)
+#    OTEL_EXPORTER_OTLP_ENDPOINT = http://$(NODE_IP):4317   (NODE_IP from downward API status.hostIP)
+#    or the agent Service: otel-agent.otel-agent.svc.cluster.local:4317
+
+# 4) Dashboard
+aws cloudwatch put-dashboard --region us-east-1 \
+  --dashboard-name OTel-Gateway-Pipeline-Health \
+  --dashboard-body file://dashboard.json
+```
+
+Region note: `gateway.yaml` pins `us-east-1` in the `otlphttp` endpoint and `sigv4auth`.
+Change both if you deploy elsewhere.
+
+## Verify
+
+```bash
+kubectl get pods -n otel-gateway     # 2/2 Running
+kubectl get pods -n otel-agent       # one per node, Running
+# Then query the gateway's own metrics in CloudWatch Query Studio (PromQL):
+#   rate(otelcol_receiver_accepted_metric_points[5m])
+```
+
+## Alarms (PromQL — create in the CloudWatch console; queries return a single series)
+
+- Queue saturation: `max(otelcol_exporter_queue_size / otelcol_exporter_queue_capacity) > 0.8`
+- Export failures: `sum(rate(otelcol_exporter_send_failed_metric_points[5m])) > 0`
+- Memory limiter (refused): `sum(rate(otelcol_receiver_refused_metric_points[5m])) > 0`
+
+## Cleanup
+
+```bash
+kubectl delete namespace otel-agent
+kubectl delete namespace otel-gateway
+aws cloudwatch delete-alarms --alarm-names "OTelGateway-QueueSaturation" "OTelGateway-ExportFailures"
+aws cloudwatch delete-dashboards --dashboard-names "OTel-Gateway-Pipeline-Health"
+```

--- a/sandbox/otel-gateway-deployment/README.md
+++ b/sandbox/otel-gateway-deployment/README.md
@@ -17,6 +17,7 @@ infrastructure Container Insights.
 | `gateway.yaml` | OTel Collector **gateway** (Deployment ×2 + Service): OTLP + Prometheus self-scrape receivers → `memory_limiter` + `batch` → `otlphttp` (`metrics_endpoint` + `sigv4auth`) to CloudWatch; `health_check` on :13133; self-telemetry on :8888. Contains an `<ACCOUNT_ID>` placeholder. |
 | `dashboard.json` | CloudWatch dashboard body (`OTel-Gateway-Pipeline-Health`) — throughput, export success vs failure, queue utilization, refused metrics. Uses PromQL `chart` widgets. |
 | `networkpolicy.yaml` | Two Kubernetes **NetworkPolicies** restricting OTLP ingress: the gateway accepts 4317/4318 only from the `otel-agent` namespace, and the agent only from your application namespaces; health/metrics ports (13133/8888) stay open for probes and scraping. Enforcement requires the VPC CNI network policy controller. |
+| `multicluster-samevpc/` | Reference sample for the "Scaling to multiple clusters" section: a hub-cluster internal-NLB Service (`gateway-nlb-service.yaml`) and a spoke-cluster agent (`agent-remote.yaml`) that forwards across the VPC to a shared gateway. See its own README. |
 
 ## Prerequisites
 

--- a/sandbox/otel-gateway-deployment/agent.yaml
+++ b/sandbox/otel-gateway-deployment/agent.yaml
@@ -129,9 +129,13 @@ spec:
           image: otel/opentelemetry-collector-contrib:0.104.0
           args: ["--config=/etc/otel/config.yaml"]
           ports:
+            # hostPort exposes the agent on the node so apps can target their
+            # node-local agent via the downward-API status.hostIP (see Step 4).
             - containerPort: 4317
+              hostPort: 4317
               name: otlp-grpc
             - containerPort: 4318
+              hostPort: 4318
               name: otlp-http
             - containerPort: 8888
               name: metrics

--- a/sandbox/otel-gateway-deployment/agent.yaml
+++ b/sandbox/otel-gateway-deployment/agent.yaml
@@ -1,0 +1,178 @@
+# =============================================================================
+# Self-managed OTel Collector AGENT tier (DaemonSet) — agent-to-gateway pattern.
+# Apps send OTLP to the node-local agent; the agent enriches with k8s metadata,
+# buffers/retries, and forwards to the gateway. The CloudWatch Observability
+# add-on stays in place for infrastructure Container Insights (separate concern).
+#
+# Resilience: the agent's sending_queue + retry_on_failure decouple apps from the
+# gateway — a transient gateway outage is absorbed here instead of dropping app data.
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-agent
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-agent
+  namespace: otel-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-agent-k8sattributes
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-agent-k8sattributes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-agent-k8sattributes
+subjects:
+  - kind: ServiceAccount
+    name: otel-agent
+    namespace: otel-agent
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-config
+  namespace: otel-agent
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 400
+        spike_limit_mib: 100
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.node.name
+            - k8s.deployment.name
+        pod_association:
+          - sources:
+              - from: connection
+      batch:
+        timeout: 10s
+
+    exporters:
+      # In-cluster hop to the gateway can use OTLP gRPC (only the CloudWatch
+      # endpoint requires HTTP). Queue + retry provide the resilience buffer.
+      otlp/gateway:
+        endpoint: otel-gateway.otel-gateway.svc.cluster.local:4317
+        tls:
+          insecure: true
+        retry_on_failure:
+          enabled: true
+          initial_interval: 1s
+          max_interval: 30s
+        sending_queue:
+          enabled: true
+          queue_size: 1000
+
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    service:
+      extensions: [health_check]
+      telemetry:
+        metrics:
+          level: normal
+          address: 0.0.0.0:8888
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, batch]
+          exporters: [otlp/gateway]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-agent
+  namespace: otel-agent
+spec:
+  selector:
+    matchLabels:
+      app: otel-agent
+  template:
+    metadata:
+      labels:
+        app: otel-agent
+    spec:
+      serviceAccountName: otel-agent
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.104.0
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 8888
+              name: metrics
+            - containerPort: 13133
+              name: health
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+      volumes:
+        - name: config
+          configMap:
+            name: otel-agent-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-agent
+  namespace: otel-agent
+spec:
+  selector:
+    app: otel-agent
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+  type: ClusterIP

--- a/sandbox/otel-gateway-deployment/dashboard.json
+++ b/sandbox/otel-gateway-deployment/dashboard.json
@@ -1,0 +1,90 @@
+{
+  "start": "-PT3H",
+  "periodOverride": "inherit",
+  "widgets": [
+    {
+      "type": "text",
+      "x": 0, "y": 0, "width": 24, "height": 2,
+      "properties": {
+        "markdown": "# OTel Gateway — Pipeline Health\nIs telemetry flowing, is it reaching CloudWatch, and are we about to lose any? Four signals: throughput in, export success vs failure, queue headroom, and dropped data."
+      }
+    },
+    {
+      "type": "chart",
+      "x": 0, "y": 2, "width": 12, "height": 8,
+      "properties": {
+        "view": "line",
+        "title": "Throughput — metrics received per second",
+        "region": "us-east-1",
+        "data": {
+          "queries": [
+            { "id": "throughput", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum(rate(otelcol_receiver_accepted_metric_points[5m]))", "label": "Received/sec", "step": 60 }
+          ]
+        },
+        "plotOptions": {
+          "legend": { "position": "bottom", "show": true },
+          "xAxis": { "type": "datetime" },
+          "yAxis": [ { "type": "linear" } ],
+          "style": { "lineOptions": { "filled": false, "pattern": "solid", "spline": false, "stacked": false, "width": 2 } }
+        }
+      }
+    },
+    {
+      "type": "chart",
+      "x": 12, "y": 2, "width": 12, "height": 8,
+      "properties": {
+        "view": "line",
+        "title": "Export success vs failure — sent vs failed per second",
+        "region": "us-east-1",
+        "data": {
+          "queries": [
+            { "id": "sent", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum(rate(otelcol_exporter_sent_metric_points[5m]))", "label": "Sent", "step": 60 },
+            { "id": "failed", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum(rate(otelcol_exporter_send_failed_metric_points[5m]))", "label": "Failed", "step": 60 }
+          ]
+        },
+        "plotOptions": {
+          "legend": { "position": "bottom", "show": true },
+          "xAxis": { "type": "datetime" },
+          "yAxis": [ { "type": "linear" } ],
+          "style": { "lineOptions": { "filled": true, "pattern": "solid", "spline": false, "stacked": true, "width": 2 } }
+        }
+      }
+    },
+    {
+      "type": "chart",
+      "x": 0, "y": 10, "width": 12, "height": 8,
+      "properties": {
+        "view": "solidgauge",
+        "title": "Queue utilization (%) — headroom before data loss",
+        "region": "us-east-1",
+        "data": {
+          "queries": [
+            { "id": "queue", "type": "cloudwatch-metrics", "language": "PromQL", "query": "max(otelcol_exporter_queue_size / otelcol_exporter_queue_capacity) * 100", "label": "Queue %", "step": 60 }
+          ]
+        },
+        "plotOptions": {
+          "legend": { "position": "bottom", "show": true },
+          "style": { "gaugeOptions": { "min": 0, "max": 100 } }
+        }
+      }
+    },
+    {
+      "type": "chart",
+      "x": 12, "y": 10, "width": 12, "height": 8,
+      "properties": {
+        "view": "number",
+        "title": "Memory limiter — refused metrics (target: 0)",
+        "region": "us-east-1",
+        "data": {
+          "queries": [
+            { "id": "refused", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum(rate(otelcol_receiver_refused_metric_points[5m]))", "label": "Refused/sec", "step": 60 }
+          ]
+        },
+        "plotOptions": {
+          "legend": { "position": "bottom", "show": true },
+          "style": { "numberOptions": { "sparkline": true, "truncate": true } }
+        }
+      }
+    }
+  ]
+}

--- a/sandbox/otel-gateway-deployment/gateway.yaml
+++ b/sandbox/otel-gateway-deployment/gateway.yaml
@@ -1,0 +1,161 @@
+# =============================================================================
+# OTel Gateway - deployable manifest (corrected)
+# Tailored for the sample-devops-agent-eks-workshop cluster used as the test bed.
+# -----------------------------------------------------------------------------
+# Fixes applied vs. the blog/test-plan source:
+#   * Receiver endpoints restored (were corrupted as [IP_ADDRESS]) -> 0.0.0.0:4317 / :4318
+#   * Prometheus self-scrape target restored -> 0.0.0.0:8888
+#   * Added health_check extension on :13133 so the liveness/readiness probes work
+#     (otherwise pods CrashLoop -> TC-03 never passes)
+#   * Region pinned to us-east-1 to match the workshop + CloudWatch OTLP + DevOps Agent preview
+#
+# Before applying:
+#   * Create the gateway IRSA role first (see irsa-role.tf) and substitute <ACCOUNT_ID>.
+#   * CloudWatch native OTLP metrics endpoint is HTTP-only and needs the sigv4auth
+#     extension + CloudWatchAgentServerPolicy on the role. (Confirmed in AWS docs.)
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-gateway
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-gateway
+  namespace: otel-gateway
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/OTelGatewayRole
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-gateway-config
+  namespace: otel-gateway
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'otel-gateway-self'
+              scrape_interval: 10s
+              static_configs:
+                - targets: ['0.0.0.0:8888']
+
+    processors:
+      batch:
+        send_batch_size: 1000
+        send_batch_max_size: 1000   # cap at CloudWatch OTLP per-request datapoint limit
+        timeout: 10s
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 1500
+        spike_limit_mib: 512
+
+    exporters:
+      otlphttp:
+        # CloudWatch native OTLP metrics endpoint is HTTP-only (no gRPC).
+        # Use metrics_endpoint (exact URL, no path appended). Using `endpoint`
+        # here would append /v1/metrics again -> .../v1/metrics/v1/metrics -> 404.
+        metrics_endpoint: https://monitoring.us-east-1.amazonaws.com/v1/metrics
+        auth:
+          authenticator: sigv4auth
+
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+      sigv4auth:
+        region: us-east-1
+        service: monitoring
+
+    service:
+      extensions: [health_check, sigv4auth]
+      telemetry:
+        metrics:
+          level: normal
+          address: 0.0.0.0:8888
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [otlphttp]
+        metrics/internal:
+          receivers: [prometheus]
+          processors: [batch]
+          exporters: [otlphttp]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-gateway
+  namespace: otel-gateway
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: otel-gateway
+  template:
+    metadata:
+      labels:
+        app: otel-gateway
+    spec:
+      serviceAccountName: otel-gateway
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.104.0
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 8888
+              name: metrics
+            - containerPort: 13133
+              name: health
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+      volumes:
+        - name: config
+          configMap:
+            name: otel-gateway-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-gateway
+  namespace: otel-gateway
+spec:
+  selector:
+    app: otel-gateway
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+  type: ClusterIP

--- a/sandbox/otel-gateway-deployment/multicluster-samevpc/README.md
+++ b/sandbox/otel-gateway-deployment/multicluster-samevpc/README.md
@@ -1,0 +1,54 @@
+# Multi-cluster (same account, same VPC) — shared gateway sample
+
+Reference manifests for the "Scaling to multiple clusters" section of the blog.
+When several EKS clusters share one VPC, you don't need a gateway in every cluster.
+Run the gateway on one cluster (the **hub**) and point the other clusters' agents
+(the **spokes**) at it through an internal Network Load Balancer.
+
+```
+spoke cluster: app → node-local agent ─┐
+spoke cluster: app → node-local agent ─┼─→ internal NLB → shared gateway (hub) → CloudWatch
+hub cluster:   app → node-local agent ─┘
+```
+
+> These are reference samples for the scaling pattern. The **tested baseline** in the
+> parent folder is the single-cluster (ClusterIP) path. The cross-cluster hop leaves the
+> pod network, so it is configured for TLS — provisioning the certs is a prerequisite.
+
+## Files
+
+| File | Where | What it is |
+|------|-------|------------|
+| `gateway-nlb-service.yaml` | hub cluster | Replaces the gateway's ClusterIP Service with an **internal NLB** so agents in the same VPC can reach ports 4317/4318. Requires the AWS Load Balancer Controller. |
+| `agent-remote.yaml` | each spoke cluster | The agent DaemonSet whose exporter targets the NLB DNS over TLS instead of the in-cluster gateway Service. |
+
+## Deploy
+
+**1. Hub cluster** — deploy the gateway (parent `gateway.yaml`), then swap its Service:
+
+```bash
+kubectl apply -f gateway-nlb-service.yaml
+# Grab the NLB hostname once provisioned:
+kubectl get svc otel-gateway -n otel-gateway \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+```
+
+**2. Each spoke cluster** — set `<GATEWAY_NLB_DNS>` in `agent-remote.yaml`, mount the
+CA (and client cert/key for mTLS), then:
+
+```bash
+kubectl apply -f agent-remote.yaml
+```
+
+Workloads on every cluster still point at their node-local agent (unchanged). The
+shared gateway handles batching, authentication, and export for all of them.
+
+## Prerequisites
+
+- All clusters in the **same account and VPC** (agents reach the internal NLB directly).
+- **AWS Load Balancer Controller** on the hub cluster.
+- **TLS certificates**: the gateway's OTLP receiver serves a cert the agents trust
+  (`ca_file`); add `cert_file`/`key_file` for mTLS so the gateway authenticates senders.
+  Cert provisioning (e.g. cert-manager) is out of scope for this Part 1 sample.
+- Restrict the NLB with a security group scoped to the sending clusters
+  (`aws-load-balancer-security-groups`).

--- a/sandbox/otel-gateway-deployment/multicluster-samevpc/agent-remote.yaml
+++ b/sandbox/otel-gateway-deployment/multicluster-samevpc/agent-remote.yaml
@@ -139,9 +139,13 @@ spec:
           image: otel/opentelemetry-collector-contrib:0.104.0
           args: ["--config=/etc/otel/config.yaml"]
           ports:
+            # hostPort exposes the agent on the node so apps can target their
+            # node-local agent via the downward-API status.hostIP (see Step 4).
             - containerPort: 4317
+              hostPort: 4317
               name: otlp-grpc
             - containerPort: 4318
+              hostPort: 4318
               name: otlp-http
             - containerPort: 8888
               name: metrics

--- a/sandbox/otel-gateway-deployment/multicluster-samevpc/agent-remote.yaml
+++ b/sandbox/otel-gateway-deployment/multicluster-samevpc/agent-remote.yaml
@@ -1,0 +1,178 @@
+# =============================================================================
+# Multi-cluster, same account, same VPC — SPOKE cluster agent.
+# Same as agent.yaml, but the agent forwards to the shared gateway across the
+# VPC via the internal NLB (see gateway-nlb-service.yaml) instead of an
+# in-cluster Service. Deploy this on each cluster that does NOT run a gateway.
+#
+# Set <GATEWAY_NLB_DNS> to the NLB hostname from the hub cluster:
+#   kubectl get svc otel-gateway -n otel-gateway \
+#     -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+#
+# TLS: this hop leaves the pod network, so it is configured for TLS
+# (insecure: false). The gateway's OTLP receiver must present a server cert and
+# the agent must trust it (ca_file); add cert_file/key_file for mTLS so the
+# gateway can authenticate senders. Provisioning those certs (e.g. cert-manager)
+# is a prerequisite and is out of scope for this Part 1 sample.
+# =============================================================================
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-agent
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-agent
+  namespace: otel-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-agent-k8sattributes
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-agent-k8sattributes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-agent-k8sattributes
+subjects:
+  - kind: ServiceAccount
+    name: otel-agent
+    namespace: otel-agent
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-config
+  namespace: otel-agent
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 400
+        spike_limit_mib: 100
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.node.name
+            - k8s.deployment.name
+        pod_association:
+          - sources:
+              - from: connection
+      batch:
+        timeout: 10s
+
+    exporters:
+      # Forward across the VPC to the shared gateway via the internal NLB.
+      otlp/gateway:
+        endpoint: <GATEWAY_NLB_DNS>:4317
+        tls:
+          insecure: false          # TLS across clusters
+          ca_file: /etc/otel/certs/ca.crt
+          # mTLS (authenticate this agent to the gateway):
+          # cert_file: /etc/otel/certs/tls.crt
+          # key_file:  /etc/otel/certs/tls.key
+        retry_on_failure:
+          enabled: true
+          initial_interval: 1s
+          max_interval: 30s
+        sending_queue:
+          enabled: true
+          queue_size: 1000
+
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    service:
+      extensions: [health_check]
+      telemetry:
+        metrics:
+          level: normal
+          address: 0.0.0.0:8888
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, batch]
+          exporters: [otlp/gateway]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-agent
+  namespace: otel-agent
+spec:
+  selector:
+    matchLabels:
+      app: otel-agent
+  template:
+    metadata:
+      labels:
+        app: otel-agent
+    spec:
+      serviceAccountName: otel-agent
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.104.0
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 8888
+              name: metrics
+            - containerPort: 13133
+              name: health
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+            # Mount the CA (and client cert/key for mTLS) the exporter references:
+            # - name: gateway-certs
+            #   mountPath: /etc/otel/certs
+            #   readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: otel-agent-config
+        # - name: gateway-certs
+        #   secret:
+        #     secretName: otel-gateway-client-certs

--- a/sandbox/otel-gateway-deployment/multicluster-samevpc/gateway-nlb-service.yaml
+++ b/sandbox/otel-gateway-deployment/multicluster-samevpc/gateway-nlb-service.yaml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Multi-cluster, same account, same VPC — HUB cluster.
+# Replaces the gateway's in-cluster ClusterIP Service with an INTERNAL Network
+# Load Balancer (L4) so agents in other clusters that share this VPC can reach
+# the gateway's OTLP ports directly. Apply this on the cluster that runs the
+# gateway (the "hub"); deploy gateway.yaml there as usual first.
+#
+# Requires the AWS Load Balancer Controller in the cluster.
+# The NLB is internal (never internet-facing). Restrict who can reach it with
+# the load-balancer security group (see aws-load-balancer-security-groups).
+#
+# NOTE: this is a reference sample for the scaling pattern. The tested baseline
+# in this repo is the single-cluster (ClusterIP) path. Cross-cluster hops leave
+# the pod network, so enable TLS on the gateway's OTLP receiver and have remote
+# agents connect over TLS/mTLS (see agent-remote.yaml and the blog).
+# =============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-gateway
+  namespace: otel-gateway
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+    # Restrict ingress to the security groups of your sending clusters:
+    # service.beta.kubernetes.io/aws-load-balancer-security-groups: "sg-xxxxxxxx"
+spec:
+  type: LoadBalancer
+  selector:
+    app: otel-gateway
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318

--- a/sandbox/otel-gateway-deployment/networkpolicy.yaml
+++ b/sandbox/otel-gateway-deployment/networkpolicy.yaml
@@ -1,0 +1,52 @@
+# NetworkPolicies — restrict who can send OTLP to the agent and gateway.
+# Data ports (4317/4318) are limited to intended senders; health/metrics ports
+# (13133/8888) stay open for kubelet probes and Prometheus scraping.
+# Enforcement requires the VPC CNI network policy controller (enabled on EKS Auto Mode).
+# Adjust the application namespace selector (sample-app) to your workload namespaces.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-gateway-allow-otlp
+  namespace: otel-gateway
+spec:
+  podSelector:
+    matchLabels:
+      app: otel-gateway
+  policyTypes: [Ingress]
+  ingress:
+    # OTLP only from the agent tier
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: otel-agent
+      ports:
+        - { port: 4317, protocol: TCP }
+        - { port: 4318, protocol: TCP }
+    # health probes (kubelet) + self-metrics scrape
+    - ports:
+        - { port: 13133, protocol: TCP }
+        - { port: 8888, protocol: TCP }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-agent-allow-otlp
+  namespace: otel-agent
+spec:
+  podSelector:
+    matchLabels:
+      app: otel-agent
+  policyTypes: [Ingress]
+  ingress:
+    # OTLP only from application namespaces (adjust to your workloads)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: sample-app
+      ports:
+        - { port: 4317, protocol: TCP }
+        - { port: 4318, protocol: TCP }
+    # health probes (kubelet) + self-metrics scrape
+    - ports:
+        - { port: 13133, protocol: TCP }
+        - { port: 8888, protocol: TCP }


### PR DESCRIPTION
## What this adds

A self-contained sandbox example under `sandbox/otel-gateway-deployment/` for running an
**agent-to-gateway OpenTelemetry pipeline on Amazon EKS** that exports metrics to Amazon
CloudWatch via the native OTLP endpoint (SigV4) and **self-monitors the gateway** ("monitor
the monitoring").

Pattern: **application → node-local OTel agent (DaemonSet) → OTel gateway (Deployment) →
CloudWatch native OTLP**. The CloudWatch Observability EKS add-on runs alongside for
infrastructure Container Insights.

## Contents

- `gateway.yaml` — OTel Collector gateway (Deployment ×2 + Service): OTLP + Prometheus
  self-scrape → `memory_limiter` + `batch` → `otlphttp` (`metrics_endpoint` + `sigv4auth`)
  to CloudWatch; `health_check` on :13133; self-telemetry on :8888.
- `agent.yaml` — node-local agent DaemonSet: OTLP receiver → `k8sattributes` + `batch` →
  forwards to the gateway; exposed via `hostPort` for node-local routing.
- `dashboard.json` — CloudWatch dashboard (`OTel-Gateway-Pipeline-Health`).
- `networkpolicy.yaml` — restricts the OTLP ports to intended senders.
- `multicluster-samevpc/` — reference sample for scaling to a shared gateway across
  clusters in one VPC (internal-NLB Service + remote-cluster agent).
- `README.md` — prerequisites, deploy, verify, alarms, cleanup.

## Testing

Validated end-to-end on a live EKS cluster (Auto Mode, K8s 1.31, us-east-1):
- app → node-local agent (via `status.hostIP`) → gateway → CloudWatch, 0 export failures.
- Gateway self-telemetry (`otelcol_*`) queryable in CloudWatch Query Studio and alertable.
- Degradation alarms fire on their conditions (export failures, queue saturation,
  memory-limiter refusals).
- Multi-cluster same-VPC path (internal NLB + TLS) validated across two clusters.

## Notes

- `gateway.yaml` pins `us-east-1` in the `otlphttp` endpoint and `sigv4auth`; change both
  for other regions. It contains an `<ACCOUNT_ID>` placeholder for the IRSA role annotation.
- No static credentials; auth to CloudWatch is via IAM Roles for Service Accounts.
