### PR TITLE
sandbox: added header comments in otel-gateway-deployment docs

### DIFF
--- a/sandbox/otel-gateway-deployment/README.md
+++ b/sandbox/otel-gateway-deployment/README.md
@@ -1,9 +1,8 @@
 # OpenTelemetry Gateway on Amazon EKS — Monitoring Your Observability Pipeline
 
-Companion manifests for the AWS blog **"Deploy OpenTelemetry Gateway on AWS: Monitoring
-Your Observability Pipeline."** They deploy an agent-to-gateway OpenTelemetry pipeline on
-Amazon EKS that exports metrics to Amazon CloudWatch via the native OTLP endpoint (SigV4)
-and self-monitors the gateway ("monitor the monitoring").
+Manifests to deploy an agent-to-gateway OpenTelemetry pipeline on Amazon EKS that exports
+metrics to Amazon CloudWatch via the native OTLP endpoint (SigV4) and self-monitors the
+gateway ("monitor the monitoring").
 
 Pattern: **application → node-local OTel agent (DaemonSet) → OTel gateway (Deployment) →
 CloudWatch native OTLP**. The CloudWatch Observability EKS add-on runs alongside for

--- a/sandbox/otel-gateway-deployment/agent.yaml
+++ b/sandbox/otel-gateway-deployment/agent.yaml
@@ -1,8 +1,9 @@
 # =============================================================================
 # Self-managed OTel Collector AGENT tier (DaemonSet) — agent-to-gateway pattern.
-# Apps send OTLP to the node-local agent; the agent enriches with k8s metadata,
-# buffers/retries, and forwards to the gateway. The CloudWatch Observability
-# add-on stays in place for infrastructure Container Insights (separate concern).
+# EKS workloads emit telemetry over OTLP to a node-local OTel agent.
+# The CloudWatch Observability EKS add-on sends infrastructure metrics and container
+# logs to CloudWatch in parallel via Container Insights. The agent enriches
+# telemetry with k8s metadata, buffers/retries, and forwards to the gateway.
 #
 # Resilience: the agent's sending_queue + retry_on_failure decouple apps from the
 # gateway — a transient gateway outage is absorbed here instead of dropping app data.

--- a/sandbox/otel-gateway-deployment/gateway.yaml
+++ b/sandbox/otel-gateway-deployment/gateway.yaml
@@ -1,18 +1,14 @@
 # =============================================================================
-# OTel Gateway - deployable manifest (corrected)
-# Tailored for the sample-devops-agent-eks-workshop cluster used as the test bed.
-# -----------------------------------------------------------------------------
-# Fixes applied vs. the blog/test-plan source:
-#   * Receiver endpoints restored (were corrupted as [IP_ADDRESS]) -> 0.0.0.0:4317 / :4318
-#   * Prometheus self-scrape target restored -> 0.0.0.0:8888
-#   * Added health_check extension on :13133 so the liveness/readiness probes work
-#     (otherwise pods CrashLoop -> TC-03 never passes)
-#   * Region pinned to us-east-1 to match the workshop + CloudWatch OTLP + DevOps Agent preview
+# OpenTelemetry Gateway — deployable manifest for Amazon EKS.
+# Receives OTLP from the agent tier, batches, and exports to the Amazon
+# CloudWatch native OTLP endpoint using SigV4. Self-scrapes its own telemetry
+# on :8888 and exposes a health_check on :13133.
 #
 # Before applying:
-#   * Create the gateway IRSA role first (see irsa-role.tf) and substitute <ACCOUNT_ID>.
-#   * CloudWatch native OTLP metrics endpoint is HTTP-only and needs the sigv4auth
-#     extension + CloudWatchAgentServerPolicy on the role. (Confirmed in AWS docs.)
+#   * Create the gateway IRSA role and substitute <ACCOUNT_ID> in the
+#     ServiceAccount annotation below.
+#   * The CloudWatch native OTLP metrics endpoint is HTTP-only and requires the
+#     sigv4auth extension plus CloudWatchAgentServerPolicy on the role.
 # =============================================================================
 apiVersion: v1
 kind: Namespace

--- a/sandbox/otel-gateway-deployment/multicluster-samevpc/README.md
+++ b/sandbox/otel-gateway-deployment/multicluster-samevpc/README.md
@@ -1,6 +1,6 @@
 # Multi-cluster (same account, same VPC) — shared gateway sample
 
-Reference manifests for the "Scaling to multiple clusters" section of the blog.
+Reference manifests for scaling to a shared gateway across multiple clusters in one VPC.
 When several EKS clusters share one VPC, you don't need a gateway in every cluster.
 Run the gateway on one cluster (the **hub**) and point the other clusters' agents
 (the **spokes**) at it through an internal Network Load Balancer.
@@ -49,6 +49,6 @@ shared gateway handles batching, authentication, and export for all of them.
 - **AWS Load Balancer Controller** on the hub cluster.
 - **TLS certificates**: the gateway's OTLP receiver serves a cert the agents trust
   (`ca_file`); add `cert_file`/`key_file` for mTLS so the gateway authenticates senders.
-  Cert provisioning (e.g. cert-manager) is out of scope for this Part 1 sample.
+  Cert provisioning (e.g. cert-manager) is out of scope for this config sample.
 - Restrict the NLB with a security group scoped to the sending clusters
   (`aws-load-balancer-security-groups`).

--- a/sandbox/otel-gateway-deployment/multicluster-samevpc/agent-remote.yaml
+++ b/sandbox/otel-gateway-deployment/multicluster-samevpc/agent-remote.yaml
@@ -12,7 +12,7 @@
 # (insecure: false). The gateway's OTLP receiver must present a server cert and
 # the agent must trust it (ca_file); add cert_file/key_file for mTLS so the
 # gateway can authenticate senders. Provisioning those certs (e.g. cert-manager)
-# is a prerequisite and is out of scope for this Part 1 sample.
+# is a prerequisite and is out of scope for this configuration below.
 # =============================================================================
 apiVersion: v1
 kind: Namespace

--- a/sandbox/otel-gateway-deployment/multicluster-samevpc/gateway-nlb-service.yaml
+++ b/sandbox/otel-gateway-deployment/multicluster-samevpc/gateway-nlb-service.yaml
@@ -12,7 +12,7 @@
 # NOTE: this is a reference sample for the scaling pattern. The tested baseline
 # in this repo is the single-cluster (ClusterIP) path. Cross-cluster hops leave
 # the pod network, so enable TLS on the gateway's OTLP receiver and have remote
-# agents connect over TLS/mTLS (see agent-remote.yaml and the blog).
+# agents connect over TLS/mTLS (see agent-remote.yaml).
 # =============================================================================
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Documentation-only cleanup of the `sandbox/otel-gateway-deployment/` example.

Changes are limited to comments and prose in the READMEs and YAML header comments. No functional or manifest changes.