### PR TITLE
Add Events page for CloudOps events

### DIFF
--- a/docusaurus/docs/events/events.json
+++ b/docusaurus/docs/events/events.json
@@ -1,0 +1,597 @@
+[
+  {
+    "theme": "One Observability Workshop",
+    "level": 300,
+    "format": "Hands-on workshop",
+    "name": "Hands-On AWS Observability: Mastering AI Operations (AIOps)",
+    "description": "Workshop Overview Join us for an intensive, hands-on workshop where you'll gain advanced practical experience with AI-powered operations (AIOps) using AWS observability services.",
+    "date": "Tue 4 Aug",
+    "time": "04:30 – 06:30 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/cd3b8/hands-on-aws-observability-mastering-ai-operations-aiops",
+    "additionalDates": [
+      {
+        "date": "Tue 4 Aug",
+        "time": "16:00 – 18:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/713b6/hands-on-aws-observability-mastering-ai-operations-aiops"
+      },
+      {
+        "date": "Tue 4 Aug",
+        "time": "17:30 – 19:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/15e96/hands-on-aws-observability-mastering-ai-operations-aiops"
+      },
+      {
+        "date": "Tue 1 Sep",
+        "time": "04:30 – 06:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/61b1d/hands-on-aws-observability-mastering-ai-operations-aiops"
+      },
+      {
+        "date": "Tue 1 Sep",
+        "time": "09:00 – 11:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/4fce3/hands-on-aws-observability-mastering-ai-operations-aiops"
+      },
+      {
+        "date": "Tue 1 Sep",
+        "time": "15:00 – 17:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/b5afa/hands-on-aws-observability-mastering-ai-operations-aiops"
+      },
+      {
+        "date": "Tue 1 Sep",
+        "time": "16:00 – 18:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/a9adb/hands-on-aws-observability-mastering-ai-operations-aiops"
+      }
+    ]
+  },
+  {
+    "theme": "One Observability Workshop",
+    "level": 300,
+    "format": "Hands-on workshop",
+    "name": "Hands-On AWS Observability: Mastering Application Performance Monitoring (APM)",
+    "description": "Workshop Overview Join us for an intensive, hands-on workshop where you'll gain advanced practical experience with Amazon CloudWatch Application Performance Monitoring (APM).",
+    "date": "Wed 5 Aug",
+    "time": "03:00 – 05:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/05cd9/hands-on-aws-observability-mastering-application-performance-monitoring-apm",
+    "additionalDates": [
+      {
+        "date": "Wed 5 Aug",
+        "time": "17:00 – 19:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/5f54b/hands-on-aws-observability-mastering-application-performance-monitoring-apm"
+      },
+      {
+        "date": "Wed 2 Sep",
+        "time": "03:00 – 05:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/a71cd/hands-on-aws-observability-mastering-application-performance-monitoring-apm"
+      },
+      {
+        "date": "Wed 2 Sep",
+        "time": "17:00 – 19:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/0a0c2/hands-on-aws-observability-mastering-application-performance-monitoring-apm"
+      }
+    ]
+  },
+  {
+    "theme": "One Observability Workshop",
+    "level": 300,
+    "format": "Hands-on workshop",
+    "name": "Hands-On AWS Observability: Mastering CloudWatch Logs",
+    "description": "Workshop Overview Join us for an intensive, hands-on workshop where you'll gain advanced practical experience with Amazon CloudWatch Logs.",
+    "date": "Wed 12 Aug",
+    "time": "03:00 – 05:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/b8114/hands-on-aws-observability-mastering-cloudwatch-logs",
+    "additionalDates": [
+      {
+        "date": "Wed 12 Aug",
+        "time": "09:00 – 11:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/a1d05/hands-on-aws-observability-mastering-cloudwatch-logs"
+      },
+      {
+        "date": "Wed 12 Aug",
+        "time": "12:00 – 14:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/8c9a7/hands-on-aws-observability-mastering-cloudwatch-logs"
+      },
+      {
+        "date": "Wed 12 Aug",
+        "time": "14:00 – 16:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/205c1/hands-on-aws-observability-mastering-cloudwatch-logs"
+      },
+      {
+        "date": "Wed 9 Sep",
+        "time": "03:00 – 05:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/e7b5b/hands-on-aws-observability-mastering-cloudwatch-logs"
+      },
+      {
+        "date": "Wed 9 Sep",
+        "time": "17:00 – 19:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/b043f/hands-on-aws-observability-mastering-cloudwatch-logs"
+      }
+    ]
+  },
+  {
+    "theme": "One Observability Workshop",
+    "level": 300,
+    "format": "Hands-on workshop",
+    "name": "Hands-On AWS Observability: Mastering CloudWatch Metrics, Alarms & Dashboards",
+    "description": "Workshop Overview Join us for an intensive, hands-on workshop where you will gain advanced practical experience with Amazon CloudWatch Metrics, Alarms, and Dashboards.",
+    "date": "Tue 11 Aug",
+    "time": "04:30 – 06:30 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/fe2a8/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards",
+    "additionalDates": [
+      {
+        "date": "Tue 11 Aug",
+        "time": "09:00 – 11:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/39e36/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards"
+      },
+      {
+        "date": "Tue 11 Aug",
+        "time": "14:00 – 16:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/23944/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards"
+      },
+      {
+        "date": "Tue 11 Aug",
+        "time": "17:30 – 19:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/9cd23/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards"
+      },
+      {
+        "date": "Tue 8 Sep",
+        "time": "04:30 – 06:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/6dc16/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards"
+      },
+      {
+        "date": "Tue 8 Sep",
+        "time": "09:00 – 11:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/66b42/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards"
+      },
+      {
+        "date": "Tue 8 Sep",
+        "time": "14:00 – 16:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/b3dbd/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards"
+      },
+      {
+        "date": "Tue 8 Sep",
+        "time": "17:30 – 19:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/6fccf/hands-on-aws-observability-mastering-cloudwatch-metrics-alarms--dashboards"
+      }
+    ]
+  },
+  {
+    "theme": "CloudWatch Fundamentals & What's New",
+    "level": 300,
+    "format": "Technical talk",
+    "name": "I didn't know Amazon CloudWatch could do that!",
+    "description": "Amazon CloudWatch has evolved from its start as an infrastructure monitoring solution into a comprehensive, full-stack observability solution powered by generative AI.",
+    "date": "Tue 11 Aug",
+    "time": "15:00 – 16:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/4b504/i-didnt-know-amazon-cloudwatch-could-do-that",
+    "additionalDates": []
+  },
+  {
+    "theme": "DevOps Agent",
+    "level": 200,
+    "format": "Hands-on workshop",
+    "name": "AWS DevOps Agent Workshop",
+    "description": "This workshop teaches AWS DevOps Agent, a frontier agent that resolves and proactively prevents incidents, continuously improving reliability and performance of your applications.",
+    "date": "Wed 22 Jul",
+    "time": "09:30 – 11:30 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/34f91/aws-devops-agent-workshop",
+    "additionalDates": [
+      {
+        "date": "Fri 24 Jul",
+        "time": "17:30 – 19:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/c78d8/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Mon 27 Jul",
+        "time": "15:00 – 17:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/936e0/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Wed 29 Jul",
+        "time": "04:00 – 06:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/6e869/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Mon 3 Aug",
+        "time": "19:00 – 21:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/84812/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Tue 4 Aug",
+        "time": "09:30 – 11:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/338ba/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Thu 6 Aug",
+        "time": "04:00 – 06:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/89661/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Mon 10 Aug",
+        "time": "17:00 – 19:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/bce51/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Thu 13 Aug",
+        "time": "09:30 – 11:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/e8c2a/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Tue 18 Aug",
+        "time": "17:30 – 19:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/e2345/aws-devops-agent-workshop"
+      },
+      {
+        "date": "Thu 20 Aug",
+        "time": "04:00 – 06:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/33426/aws-devops-agent-workshop"
+      }
+    ]
+  },
+  {
+    "theme": "DevOps Agent",
+    "level": 300,
+    "format": "Technical talk",
+    "name": "DevOps Agent Meets DMS: Autonomous Troubleshooting for Replication Issues",
+    "description": "Join us for a 60-minute live session showing how Amazon DevOps Agent turns AWS Database Migration Service (DMS) operations from reactive break-fix into autonomous, proactive troubleshooting.",
+    "date": "Thu 30 Jul",
+    "time": "17:00 – 18:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/58940/devops-agent-meets-dms-autonomous-troubleshooting-for-replication-issues",
+    "additionalDates": []
+  },
+  {
+    "theme": "DevOps Agent",
+    "level": 200,
+    "format": "Technical talk",
+    "name": "Evolution of the Single Pane of Glass: From Dashboards to DevOps Agents",
+    "description": "IT teams still spend 40% of their time manually correlating data across dashboards—despite promises of simplified troubleshooting.",
+    "date": "Tue 21 Jul",
+    "time": "15:00 – 16:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/c14e6/evolution-of-the-single-pane-of-glass-from-dashboards-to-devops-agents",
+    "additionalDates": [
+      {
+        "date": "Wed 22 Jul",
+        "time": "19:00 – 20:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/102e7/evolution-of-the-single-pane-of-glass-from-dashboards-to-devops-agents"
+      },
+      {
+        "date": "Tue 25 Aug",
+        "time": "15:00 – 16:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/e599e/evolution-of-the-single-pane-of-glass-from-dashboards-to-devops-agents"
+      },
+      {
+        "date": "Wed 26 Aug",
+        "time": "19:00 – 20:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/8b1bb/evolution-of-the-single-pane-of-glass-from-dashboards-to-devops-agents"
+      },
+      {
+        "date": "Thu 27 Aug",
+        "time": "04:30 – 05:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/16908/evolution-of-the-single-pane-of-glass-from-dashboards-to-devops-agents"
+      },
+      {
+        "date": "Thu 27 Aug",
+        "time": "11:00 – 12:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/33a2d/evolution-of-the-single-pane-of-glass-from-dashboards-to-devops-agents"
+      }
+    ]
+  },
+  {
+    "theme": "DevOps Agent",
+    "level": 300,
+    "format": "Technical talk",
+    "name": "What makes AWS DevOps Agent Different",
+    "description": "AWS DevOps Agent is a fully managed operational teammate designed to transform how your team works.",
+    "date": "Thu 30 Jul",
+    "time": "16:00 – 17:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/d5541/what-makes-aws-devops-agent-different",
+    "additionalDates": [
+      {
+        "date": "Wed 5 Aug",
+        "time": "16:00 – 17:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/e9a72/what-makes-aws-devops-agent-different"
+      },
+      {
+        "date": "Thu 13 Aug",
+        "time": "16:00 – 17:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/da0ec/what-makes-aws-devops-agent-different"
+      }
+    ]
+  },
+  {
+    "theme": "GenAI Observability",
+    "level": 300,
+    "format": "Technical talk",
+    "name": "CloudWatch GenAI Observability for Amazon Bedrock and Bedrock AgentCore",
+    "description": "Get started with GenAI observability – Set up foundational observability for your GenAI workloads by understanding what telemetry is automatically available for your Bedrock and AgentCore applications and how to acces…",
+    "date": "Tue 28 Jul",
+    "time": "10:00 – 11:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/54b12/cloudwatch-genai-observability-for-amazon-bedrock-and-bedrock-agentcore",
+    "additionalDates": [
+      {
+        "date": "Tue 28 Jul",
+        "time": "18:00 – 19:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/3c3b4/cloudwatch-genai-observability-for-amazon-bedrock-and-bedrock-agentcore"
+      },
+      {
+        "date": "Wed 29 Jul",
+        "time": "04:00 – 05:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/1c08c/cloudwatch-genai-observability-for-amazon-bedrock-and-bedrock-agentcore"
+      },
+      {
+        "date": "Tue 25 Aug",
+        "time": "18:00 – 19:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/d57fd/cloudwatch-genai-observability-for-amazon-bedrock-and-bedrock-agentcore"
+      },
+      {
+        "date": "Wed 26 Aug",
+        "time": "04:00 – 05:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/1add5/cloudwatch-genai-observability-for-amazon-bedrock-and-bedrock-agentcore"
+      }
+    ]
+  },
+  {
+    "theme": "GenAI Observability",
+    "level": 300,
+    "format": "Technical talk",
+    "name": "End-to-End GenAI Observability: Infrastructure, Agents, and Applications",
+    "description": "CloudWatch OTLP for Metrics Leverage OpenTelemetry Protocol (OTLP) for standardized metrics collection Configure CloudWatch to receive OTLP metrics from distributed GenAI workloads Enable vendor-agnostic observability…",
+    "date": "Tue 21 Jul",
+    "time": "19:00 – 20:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/b1994/end-to-end-genai-observability-infrastructure-agents-and-applications",
+    "additionalDates": [
+      {
+        "date": "Wed 22 Jul",
+        "time": "09:00 – 10:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/617ea/end-to-end-genai-observability-infrastructure-agents-and-applications"
+      },
+      {
+        "date": "Thu 23 Jul",
+        "time": "04:30 – 05:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/ce8e7/end-to-end-genai-observability-infrastructure-agents-and-applications"
+      },
+      {
+        "date": "Thu 23 Jul",
+        "time": "04:30 – 05:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/71c2b/end-to-end-genai-observability-infrastructure-agents-and-applications"
+      },
+      {
+        "date": "Tue 25 Aug",
+        "time": "04:30 – 05:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/a7f35/end-to-end-genai-observability-infrastructure-agents-and-applications"
+      },
+      {
+        "date": "Tue 25 Aug",
+        "time": "09:00 – 10:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/da5d7/end-to-end-genai-observability-infrastructure-agents-and-applications"
+      },
+      {
+        "date": "Wed 26 Aug",
+        "time": "19:00 – 20:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/1dc07/end-to-end-genai-observability-infrastructure-agents-and-applications"
+      }
+    ]
+  },
+  {
+    "theme": "GenAI Observability",
+    "level": 300,
+    "format": "Hands-on workshop",
+    "name": "Optimizing GenAI performance with Amazon CloudWatch",
+    "description": "In this hands-on workshop, you will learn how to gain full visibility into your generative AI applications using Amazon CloudWatch's observability features for GenAI workloads.",
+    "date": "Thu 13 Aug",
+    "time": "04:30 – 06:30 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/8b8ca/optimizing-genai-performance-with-amazon-cloudwatch",
+    "additionalDates": [
+      {
+        "date": "Thu 13 Aug",
+        "time": "16:00 – 18:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/46b1b/optimizing-genai-performance-with-amazon-cloudwatch"
+      },
+      {
+        "date": "Thu 13 Aug",
+        "time": "17:30 – 19:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/beb5f/optimizing-genai-performance-with-amazon-cloudwatch"
+      },
+      {
+        "date": "Thu 10 Sep",
+        "time": "04:30 – 06:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/76628/optimizing-genai-performance-with-amazon-cloudwatch"
+      },
+      {
+        "date": "Thu 10 Sep",
+        "time": "16:00 – 18:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/f86e1/optimizing-genai-performance-with-amazon-cloudwatch"
+      },
+      {
+        "date": "Thu 10 Sep",
+        "time": "17:30 – 19:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/afff7/optimizing-genai-performance-with-amazon-cloudwatch"
+      }
+    ]
+  },
+  {
+    "theme": "Database Observability",
+    "level": 300,
+    "format": "Hands-on workshop",
+    "name": "Hands-On AWS Observability: Mastering Database Observability",
+    "description": "Workshop Overview Join us for an intensive, hands-on workshop where you'll gain advanced practical experience with Amazon CloudWatch Database Insights.",
+    "date": "Thu 6 Aug",
+    "time": "04:30 – 06:30 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/e74fc/hands-on-aws-observability-mastering-database-observability",
+    "additionalDates": [
+      {
+        "date": "Thu 6 Aug",
+        "time": "15:00 – 17:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/375e5/hands-on-aws-observability-mastering-database-observability"
+      },
+      {
+        "date": "Thu 3 Sep",
+        "time": "04:30 – 06:30 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/7ce3a/hands-on-aws-observability-mastering-database-observability"
+      },
+      {
+        "date": "Thu 3 Sep",
+        "time": "15:00 – 17:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/1d8e8/hands-on-aws-observability-mastering-database-observability"
+      }
+    ]
+  },
+  {
+    "theme": "Database Observability",
+    "level": 200,
+    "format": "Technical talk",
+    "name": "How to Transition from Performance Insights to CloudWatch Database Insights",
+    "description": "Join this 60-minute session to learn how to transition from Performance Insights to CloudWatch Database Insights with zero gaps in your monitoring coverage.",
+    "date": "Wed 29 Jul",
+    "time": "16:00 – 17:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/98e20/how-to-transition-from-performance-insights-to-cloudwatch-database-insights",
+    "additionalDates": []
+  },
+  {
+    "theme": "Database Observability",
+    "level": 300,
+    "format": "Technical talk",
+    "name": "Zero to Hero: Improve Operations by Gaining Actionable Database Insights with CloudWatch",
+    "description": "Transform Your Database Operations Struggling with database performance issues?",
+    "date": "Wed 19 Aug",
+    "time": "17:00 – 18:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/0b9e8/zero-to-hero-improve-operations-by-gaining-actionable-database-insights-with-cloudwatch",
+    "additionalDates": [
+      {
+        "date": "Wed 16 Sep",
+        "time": "17:00 – 18:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/8c0a6/zero-to-hero-improve-operations-by-gaining-actionable-database-insights-with-cloudwatch"
+      }
+    ]
+  },
+  {
+    "theme": "Security Visibility",
+    "level": 300,
+    "format": "Hands-on workshop",
+    "name": "Simplified Security Visibility - CloudWatch Unified Data Store",
+    "description": "The AWS Events for Security Visibility and Analytics Activation Day provides hands-on experience working with AWS CloudTrail Management Events and Data Events in the Amazon CloudWatch unified data store.",
+    "date": "Tue 28 Jul",
+    "time": "02:00 – 04:00 UTC",
+    "location": "Online",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/08b03/simplified-security-visibility---cloudwatch-unified-data-store",
+    "additionalDates": [
+      {
+        "date": "Tue 28 Jul",
+        "time": "14:00 – 16:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/294f2/simplified-security-visibility---cloudwatch-unified-data-store"
+      },
+      {
+        "date": "Mon 24 Aug",
+        "time": "14:00 – 16:00 UTC",
+        "location": "Online",
+        "registerUrl": "https://aws-experience.com/amer/smb/e/b4e22/simplified-security-visibility---cloudwatch-unified-data-store"
+      }
+    ]
+  },
+  {
+    "theme": "Regional & In-Person Events",
+    "level": 200,
+    "format": "In-person event",
+    "name": "Dallas CloudOps Regional Event",
+    "description": "Dallas CloudOps Regional Event",
+    "date": "Thu 3 Sep",
+    "time": "15:00 – 17:00 UTC",
+    "location": "In-person",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/3f7ac/dallas-cloudops-regional-event",
+    "additionalDates": []
+  },
+  {
+    "theme": "Regional & In-Person Events",
+    "level": 200,
+    "format": "In-person event",
+    "name": "Evento para Partner: Observabilidad y Operaciones con IA by TD SYNNEX",
+    "description": "El futuro de las operaciones en la nube es inteligente, automatizado y observable.",
+    "date": "Tue 28 Jul",
+    "time": "21:00 – 00:00 UTC",
+    "location": "In-person",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/bfa0c/observabilidad-y-operaciones-con-ia-de-la-vision-a-la-practica-by-td-synnex",
+    "additionalDates": []
+  },
+  {
+    "theme": "Regional & In-Person Events",
+    "level": 200,
+    "format": "In-person event",
+    "name": "Observabilidad y Operaciones con IA: De la Visión a la Práctica by Cloudgenia & TD SYNNEX",
+    "description": "El futuro de las operaciones en la nube es inteligente, automatizado y observable.",
+    "date": "Thu 30 Jul",
+    "time": "14:30 – 23:00 UTC",
+    "location": "In-person",
+    "registerUrl": "https://aws-experience.com/amer/smb/e/95132/observabilidad-y-operaciones-con-ia-de-la-vision-a-la-practica-mexico-by-cloudgenia",
+    "additionalDates": []
+  }
+]

--- a/docusaurus/docs/events/index.mdx
+++ b/docusaurus/docs/events/index.mdx
@@ -1,0 +1,13 @@
+---
+sidebar_position: 6
+title: Events
+hide_table_of_contents: true
+---
+
+import EventGrid from '@site/src/components/EventCard';
+import events from './events.json';
+
+# Cloud Operations Enablement Events
+
+<EventGrid events={events} />
+

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -168,6 +168,13 @@ const config = {
           },
           {
             type: 'doc',
+            docId: 'events/index',
+            position: 'left',
+            label: 'Events',
+            sidebarId: false,
+          },
+          {
+            type: 'doc',
             docId: 'resources/index',
             position: 'left',
             label: 'Resources',

--- a/docusaurus/src/components/EventCard/index.js
+++ b/docusaurus/src/components/EventCard/index.js
@@ -1,0 +1,190 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+const MONTHS = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 };
+
+// Theme display order and short descriptions. Add/adjust here to change the page sections.
+const THEME_ORDER = [
+  'One Observability Workshop',
+  "CloudWatch Fundamentals & What's New",
+  'DevOps Agent',
+  'GenAI Observability',
+  'Database Observability',
+  'Security Visibility',
+  'Regional & In-Person Events',
+];
+
+const THEME_INFO = {
+  'One Observability Workshop':
+    'Intensive hands-on labs across the full AWS observability toolset — metrics, alarms, dashboards, logs, application performance monitoring, and AI operations.',
+  "CloudWatch Fundamentals & What's New":
+    'Get started with Amazon CloudWatch and see the latest observability capabilities launched in recent months.',
+  'DevOps Agent':
+    'See how AWS DevOps Agent turns operations from reactive break-fix into autonomous, proactive troubleshooting.',
+  'GenAI Observability':
+    'End-to-end observability for your generative AI stack — models, agents, tools, and applications on Amazon Bedrock and beyond.',
+  'Database Observability':
+    'Monitor database performance, detect anomalies, and transition from Performance Insights to CloudWatch Database Insights with zero monitoring gaps.',
+  'Security Visibility':
+    'Hands-on with AWS CloudTrail events in the Amazon CloudWatch unified data store for simplified security visibility.',
+  'Regional & In-Person Events':
+    'In-person and regional CloudOps events — hands-on observability and operations guidance with the AWS team.',
+};
+
+function parseDate(dateStr) {
+  const m = (dateStr || '').match(/(\d{1,2})\s+([A-Za-z]{3})/);
+  if (!m) return null;
+  const now = new Date();
+  const month = MONTHS[m[2]] ?? 0;
+  const day = parseInt(m[1], 10);
+  // Dates without a year: assume current year, but if the date is more than
+  // 3 months in the past, assume next year (handles Dec→Jan rollover).
+  let year = now.getFullYear();
+  const candidate = new Date(year, month, day);
+  const threeMonthsAgo = new Date(now);
+  threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+  if (candidate < threeMonthsAgo) {
+    year += 1;
+  }
+  return new Date(year, month, day);
+}
+
+function dateKey(dateStr) {
+  const d = parseDate(dateStr);
+  return d ? d.getTime() : Number.MAX_SAFE_INTEGER;
+}
+
+// Returns true if the session date is today or in the future.
+function isFutureOrToday(dateStr) {
+  const d = parseDate(dateStr);
+  if (!d) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return d >= today;
+}
+
+// Display label for a session's location: "Online" is shown as "Virtual".
+function locationLabel(location) {
+  const loc = (location || '').trim();
+  if (/^online$/i.test(loc)) return 'Virtual';
+  return loc;
+}
+
+// Recognize which region a session's time slot targets (shown instead of the clock time).
+function deriveGeo(session, eventName) {
+  const loc = (session.location || '').toLowerCase();
+  const name = (eventName || '').toLowerCase();
+  if (loc.includes('in-person')) {
+    if (/m[eé]xico|observabilidad|cloudgenia|synnex/.test(name)) return 'LATAM';
+    return 'NAMER';
+  }
+  const m = (session.time || '').match(/(\d{1,2}):(\d{2})/);
+  const hour = m ? parseInt(m[1], 10) : 12;
+  if (hour < 8) return 'APJ';
+  if (hour < 14) return 'EMEA';
+  return 'NAMER';
+}
+
+// Flatten one event entry into sessions, each carrying its region, event name and level.
+function sessionsForEvent(event) {
+  const all = [
+    { date: event.date, time: event.time, location: event.location, registerUrl: event.registerUrl },
+    ...(event.additionalDates || []),
+  ];
+  return all.map((s) => ({ ...s, geo: deriveGeo(s, event.name), eventName: event.name, level: event.level }));
+}
+
+function GeoBadge({ geo }) {
+  return <span className={`${styles.geoBadge} ${styles['geo' + geo]}`}>{geo}</span>;
+}
+
+// One card per theme: the soonest session across all events is surfaced as NEXT SESSION,
+// and every remaining session (from every event in the theme) is listed in one dropdown.
+function ThemeCard({ theme, sessions }) {
+  const next = sessions[0];
+  const rest = sessions.slice(1);
+  if (!next) return null;
+
+  return (
+    <article className={styles.eventCard}>
+      <h2 className={styles.themeHeading}>{theme}</h2>
+      <p className={styles.themeDesc}>{THEME_INFO[theme]}</p>
+      <div className={styles.nextSession}>
+        <div className={styles.nextMeta}>
+          <span className={styles.nextLabel}>
+            NEXT SESSION <span className={styles.nextLevel}>LEVEL {next.level}</span>
+          </span>
+          <span className={styles.nextName}>{next.eventName}</span>
+          <span className={styles.nextDate}>{next.date}</span>
+          <span className={styles.nextWhere}>
+            <GeoBadge geo={next.geo} /> · {locationLabel(next.location)}
+          </span>
+        </div>
+        <a
+          className={styles.registerButton}
+          href={next.registerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          REGISTER →
+        </a>
+      </div>
+
+      {rest.length > 0 && (
+        <details className={styles.moreDates}>
+          <summary className={styles.moreSummary}>
+            {rest.length} more session{rest.length > 1 ? 's' : ''}
+          </summary>
+          <ul className={styles.dateList}>
+            {rest.map((s, j) => (
+              <li key={j} className={styles.dateRow}>
+                <div className={styles.dateMeta}>
+                  <span className={styles.dateWhen}>{s.date}</span>
+                  <GeoBadge geo={s.geo} />
+                  <span className={styles.dateName}>{s.eventName}</span>
+                  <span className={styles.dateLoc}>· {locationLabel(s.location)}</span>
+                </div>
+                <a
+                  className={styles.registerButtonSmall}
+                  href={s.registerUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Register →
+                </a>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </article>
+  );
+}
+
+export default function EventGrid({ events }) {
+  const themes = THEME_ORDER.map((theme) => {
+    const sessions = events
+      .filter((e) => e.theme === theme)
+      .flatMap(sessionsForEvent)
+      .filter((s) => isFutureOrToday(s.date))
+      .sort((a, b) => dateKey(a.date) - dateKey(b.date));
+    return { theme, sessions };
+  }).filter((t) => t.sessions.length > 0);
+
+  return (
+    <div className={styles.eventsPage}>
+      <p className={styles.leadText}>
+        Free, live webinars and hands-on workshops from the teams that build and operate AWS Cloud
+        Operations services. Browse by topic below — each category shows its soonest session for quick
+        sign-up, with every remaining session under <strong>more sessions</strong>. Region is labeled
+        on every session.
+      </p>
+
+      <div className={styles.eventGrid}>
+        {themes.map(({ theme, sessions }) => (
+          <ThemeCard key={theme} theme={theme} sessions={sessions} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docusaurus/src/components/EventCard/styles.module.css
+++ b/docusaurus/src/components/EventCard/styles.module.css
@@ -1,0 +1,243 @@
+/* ===== CloudOps events: 7 theme groups, each one card + one combined session dropdown ===== */
+
+.eventsPage {
+  margin-top: 0.5rem;
+}
+
+.leadText {
+  font-size: 1.05rem;
+  color: var(--ifm-color-emphasis-800);
+  max-width: 820px;
+  margin-bottom: 1.75rem;
+}
+
+/* Grid of theme boxes */
+.eventGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.themeHeading {
+  font-size: 1.2rem;
+  margin: 0 0 0.35rem;
+  color: var(--ifm-heading-color);
+}
+
+.themeDesc {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0 0 1rem;
+}
+
+.eventCard {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  background: var(--ifm-background-surface-color);
+  padding: 1.2rem 1.3rem 1rem;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.eventCard:hover {
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.1);
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+/* NEXT SESSION block (accent bar) */
+.nextSession {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: auto;
+  border-left: 3px solid #ff9900;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 0 8px 8px 0;
+  padding: 0.7rem 0.9rem;
+}
+
+.nextMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.nextLabel {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.nextLevel {
+  display: inline-block;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-left: 0.35rem;
+  vertical-align: middle;
+}
+
+.nextName {
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin-top: 2px;
+}
+
+.nextDate {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.nextWhere {
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-700);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.registerButton {
+  flex-shrink: 0;
+  background: #232f3e;
+  color: #fff !important;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  padding: 6px 14px;
+  border-radius: 6px;
+  text-decoration: none !important;
+  white-space: nowrap;
+}
+
+.registerButton:hover {
+  background: #ff9900;
+  color: #232f3e !important;
+}
+
+[data-theme='dark'] .registerButton {
+  background: #ff9900;
+  color: #232f3e !important;
+}
+
+/* "N more sessions" dropdown */
+.moreDates {
+  margin-top: 0.6rem;
+}
+
+.moreSummary {
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  padding: 0.35rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  user-select: none;
+}
+
+.moreSummary::-webkit-details-marker {
+  display: none;
+}
+
+.moreSummary::before {
+  content: '▸';
+  color: #ff9900;
+  transition: transform 0.15s ease;
+}
+
+.moreDates[open] .moreSummary::before {
+  transform: rotate(90deg);
+}
+
+.dateList {
+  list-style: none;
+  margin: 0.25rem 0 0;
+  padding: 0;
+}
+
+.dateRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid var(--ifm-color-emphasis-100);
+}
+
+.dateMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.dateWhen {
+  font-weight: 700;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.dateName {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.dateLoc {
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.registerButtonSmall {
+  flex-shrink: 0;
+  background: #232f3e;
+  color: #fff !important;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 4px 11px;
+  border-radius: 6px;
+  text-decoration: none !important;
+  white-space: nowrap;
+}
+
+.registerButtonSmall:hover {
+  background: #ff9900;
+  color: #232f3e !important;
+}
+
+[data-theme='dark'] .registerButtonSmall {
+  background: #ff9900;
+  color: #232f3e !important;
+}
+
+/* Region badges */
+.geoBadge {
+  display: inline-block;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #fff;
+  padding: 1px 7px;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
+.geoNAMER { background: #2196F3; }
+.geoEMEA  { background: #4CAF50; }
+.geoAPJ   { background: #FF9800; }
+.geoLATAM { background: #9C27B0; }


### PR DESCRIPTION
- Add Events link to top navbar pointing to docs/events/index
- No sidebar generated for Events page (top nav only)
- Filter out past sessions in EventCard so the next future date
  always appears as the main "NEXT SESSION" card
- Theme cards with no upcoming sessions are hidden automatically
