### PR TITLE
fix(ci): Ignore local image paths in markdown-link-check

### DIFF
--- a/.github/workflows/linkcheck.json
+++ b/.github/workflows/linkcheck.json
@@ -19,6 +19,9 @@
   ],
   "ignorePatterns": [
     {
+      "pattern": "^/img/"
+    },
+    {
       "pattern": "^../"
     },
     {


### PR DESCRIPTION
Add /img/ to ignorePatterns in linkcheck.json to prevent false failures on Docusaurus static asset references. These paths are validated by the Docusaurus build step and cannot be resolved by markdown-link-check without a running local server.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

