### PR TITLE
fix(catalog): Derive honest last_validated dates and remove all pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,12 @@ Before authoring or modifying content, read:
 - **`last_validated` is a promise, not a timestamp.** It means a human re-tested
   the steps. Do not update it unless that happened.
 - **Ordering is `featured`, then `last_validated` descending, then name.** It is
-  not relevance ranked.
+  not relevance ranked. No entry currently sets `featured`, so in practice the
+  catalog is ordered by freshness.
+- **`last_validated` reflects the vintage of the content, not the file.** Entries
+  converted from older material inherit that material's date, so a recent commit
+  to an entry does not mean its instructions were recently verified. Several
+  entries are deliberately over a year old; that is a visible re-test backlog,
+  not a defect.
 - Only English is published. Translation files exist under `docusaurus/i18n/`
   but no locale covers the catalog yet.

--- a/docusaurus/docs/solutions/_catalog/CONTRIBUTING.md
+++ b/docusaurus/docs/solutions/_catalog/CONTRIBUTING.md
@@ -183,7 +183,31 @@ Group-level synonyms (those keyed to a `workload_type` value) may contain **only
 
 `catalog.json` is **generated** — never hand-edit it. The generator reads every `meta.yaml`, validates it, and writes the catalog file.
 
-Entries are ordered by `last_validated` descending. The freshest 9 entries land on page 1 of the catalog homepage. Bumping the date without actually re-testing the steps is a **review-blocking offense** — reviewers will check the commit diff against the entry content.
+Entries are ordered by `featured` first, then `last_validated` descending, then name. The freshest 9 entries land on page 1 of the catalog homepage.
+
+### `last_validated` must be a real date
+
+It records **when a human last verified this entry's steps against reality**. It is not the date you edited the file, and it is not a dial for controlling placement.
+
+Three rules follow from that:
+
+1. **Bumping the date without re-testing is a review-blocking offense.** Reviewers check the commit diff against the entry content.
+2. **Editing prose does not refresh it.** Fixing a typo, a link, or a caption leaves the date alone, because none of that revalidates the instructions.
+3. **When converting existing material, inherit the source's date**, not today's. Use the last commit date of the files you drew from:
+   ```bash
+   git log -1 --format=%cs -- <source paths>
+   ```
+   An entry assembled from a 2024 guide is 2024-vintage content in a new wrapper. Dating it today claims a verification that never happened.
+
+The validator warns when an entry passes 365 days. Those warnings are the point: they are the re-test backlog, and a catalog that shows several is being honest rather than broken.
+
+### `featured` is deliberately rare
+
+`featured: true` pins an entry above the date ordering. It exists for a genuine editorial reason to override freshness, and **no entry currently carries it**.
+
+It was previously applied to 18 entries to keep reviewed content ahead of bulk-converted content. That inverted its own purpose: new, deliberately authored entries defaulted to unpinned and landed on page 3, below older pinned material. Reviewed-versus-unreviewed is not a thing the catalog should model at all, since anything merged has been reviewed.
+
+If you pin something, expect to justify it in review and to unpin it later.
 
 To regenerate after adding or updating an entry:
 

--- a/docusaurus/docs/solutions/adot-at-scale/meta.yaml
+++ b/docusaurus/docs/solutions/adot-at-scale/meta.yaml
@@ -13,5 +13,5 @@ iac_available: []
 partner_integrations: []
 accelerator_link: ""
 docs_link: "https://aws-otel.github.io/docs/getting-started/collector"
-last_validated: "2026-08-20"
+last_validated: "2024-09-30"
 related_events: []

--- a/docusaurus/docs/solutions/ai-workload-audit-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/ai-workload-audit-monitoring/meta.yaml
@@ -6,7 +6,7 @@ workload_type: [ai-ml, security]
 backends: [cloudwatch]
 signals: [logs, metrics, traces]
 status: active
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 partner_integrations: []
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html"

--- a/docusaurus/docs/solutions/aws-config-compliance/meta.yaml
+++ b/docusaurus/docs/solutions/aws-config-compliance/meta.yaml
@@ -13,5 +13,5 @@ instrumentation: custom
 status: active
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 related_events: [security]

--- a/docusaurus/docs/solutions/aws-organizations-and-regions/meta.yaml
+++ b/docusaurus/docs/solutions/aws-organizations-and-regions/meta.yaml
@@ -7,5 +7,5 @@ backends: [cloudwatch]
 signals: [logs]
 status: active
 docs_link: "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 related_events: []

--- a/docusaurus/docs/solutions/big-data-observability/meta.yaml
+++ b/docusaurus/docs/solutions/big-data-observability/meta.yaml
@@ -13,5 +13,5 @@ iac_available: []
 partner_integrations: []
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-manage-view-web-log-files.html"
-last_validated: "2026-08-20"
+last_validated: "2024-09-30"
 related_events: []

--- a/docusaurus/docs/solutions/cloudtrail-cost-optimization/meta.yaml
+++ b/docusaurus/docs/solutions/cloudtrail-cost-optimization/meta.yaml
@@ -8,5 +8,5 @@ signals: [logs]
 status: active
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-trail-pricing.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 related_events: []

--- a/docusaurus/docs/solutions/cloudtrail-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/cloudtrail-monitoring/meta.yaml
@@ -13,5 +13,5 @@ instrumentation: custom
 status: active
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 related_events: []

--- a/docusaurus/docs/solutions/cloudtrail-security-forensics/meta.yaml
+++ b/docusaurus/docs/solutions/cloudtrail-security-forensics/meta.yaml
@@ -8,5 +8,5 @@ signals: [logs]
 status: active
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 related_events: [security]

--- a/docusaurus/docs/solutions/cloudwatch-agent-configuration/meta.yaml
+++ b/docusaurus/docs/solutions/cloudwatch-agent-configuration/meta.yaml
@@ -7,5 +7,5 @@ backends: [cloudwatch]
 signals: [metrics, logs]
 status: active
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html"
-last_validated: "2026-08-20"
+last_validated: "2026-02-20"
 related_events: [cloudwatch, metrics]

--- a/docusaurus/docs/solutions/cloudwatch-dashboards/meta.yaml
+++ b/docusaurus/docs/solutions/cloudwatch-dashboards/meta.yaml
@@ -6,6 +6,6 @@ workload_type: [applications]
 backends: [cloudwatch]
 signals: [metrics, logs]
 status: active
-last_validated: "2026-08-20"
+last_validated: "2026-05-20"
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html"
 related_events: [cloudwatch, metrics]

--- a/docusaurus/docs/solutions/cloudwatch-logs-analysis/meta.yaml
+++ b/docusaurus/docs/solutions/cloudwatch-logs-analysis/meta.yaml
@@ -7,5 +7,5 @@ backends: [cloudwatch]
 signals: [logs]
 status: active
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html"
-last_validated: "2026-08-20"
+last_validated: "2026-07-10"
 related_events: [logs, cloudwatch]

--- a/docusaurus/docs/solutions/cloudwatch-logs-security/meta.yaml
+++ b/docusaurus/docs/solutions/cloudwatch-logs-security/meta.yaml
@@ -6,7 +6,6 @@ workload_type: [security]
 backends: [cloudwatch]
 signals: [logs]
 status: active
-featured: true
-last_validated: "2026-08-18"
+last_validated: "2026-01-12"
 docs_link: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/security.html
 related_events: [security]

--- a/docusaurus/docs/solutions/cloudwatch-metrics/meta.yaml
+++ b/docusaurus/docs/solutions/cloudwatch-metrics/meta.yaml
@@ -6,6 +6,6 @@ workload_type: [applications]
 backends: [cloudwatch]
 signals: [metrics]
 status: active
-last_validated: "2026-08-20"
+last_validated: "2026-05-20"
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html"
 related_events: [cloudwatch, metrics]

--- a/docusaurus/docs/solutions/coding-agents-observability/meta.yaml
+++ b/docusaurus/docs/solutions/coding-agents-observability/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 30
 instrumentation: otel
 status: active
-featured: true
 accelerator_link: ""
 docs_link: ""
-last_validated: "2026-08-17"
+last_validated: "2026-06-22"

--- a/docusaurus/docs/solutions/control-tower-landing-zone/meta.yaml
+++ b/docusaurus/docs/solutions/control-tower-landing-zone/meta.yaml
@@ -7,4 +7,4 @@ backends: [cloudwatch]
 signals: [logs]
 status: active
 docs_link: "https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"

--- a/docusaurus/docs/solutions/cross-account-observability/meta.yaml
+++ b/docusaurus/docs/solutions/cross-account-observability/meta.yaml
@@ -9,7 +9,7 @@ signals: [metrics, logs, traces]
 instrumentation: custom
 status: active
 time_to_value_minutes: 40
-last_validated: "2026-08-20"
+last_validated: "2025-04-23"
 iac_available: []
 partner_integrations: []
 accelerator_link: ""

--- a/docusaurus/docs/solutions/databricks-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/databricks-monitoring/meta.yaml
@@ -13,5 +13,5 @@ iac_available: []
 partner_integrations: ["Databricks"]
 accelerator_link: ""
 docs_link: ""
-last_validated: "2026-08-20"
+last_validated: "2024-09-30"
 related_events: []

--- a/docusaurus/docs/solutions/distributed-tracing/meta.yaml
+++ b/docusaurus/docs/solutions/distributed-tracing/meta.yaml
@@ -7,5 +7,5 @@ backends: [xray, cloudwatch]
 signals: [traces]
 status: active
 docs_link: "https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-20"
 related_events: [apm]

--- a/docusaurus/docs/solutions/dotnet-application-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/dotnet-application-monitoring/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 30
 instrumentation: otel
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html"
-last_validated: "2026-08-17"
+last_validated: "2025-05-29"

--- a/docusaurus/docs/solutions/ec2-nginx/meta.yaml
+++ b/docusaurus/docs/solutions/ec2-nginx/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 15
 instrumentation: cwagent
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html"
-last_validated: "2026-05-10"
+last_validated: "2026-08-18"

--- a/docusaurus/docs/solutions/ecs-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/ecs-monitoring/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 25
 instrumentation: adot
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html"
-last_validated: "2026-08-17"
+last_validated: "2024-09-30"

--- a/docusaurus/docs/solutions/eks-application-signals/meta.yaml
+++ b/docusaurus/docs/solutions/eks-application-signals/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 20
 instrumentation: otel
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html"
-last_validated: "2026-06-20"
+last_validated: "2026-08-18"

--- a/docusaurus/docs/solutions/eks-container-insights/meta.yaml
+++ b/docusaurus/docs/solutions/eks-container-insights/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 15
 instrumentation: cwagent
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html"
-last_validated: "2026-08-17"
+last_validated: "2026-08-10"

--- a/docusaurus/docs/solutions/eks-infrastructure/meta.yaml
+++ b/docusaurus/docs/solutions/eks-infrastructure/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 30
 instrumentation: otel
 status: active
-featured: true
 accelerator_link: "https://github.com/aws-observability/terraform-aws-observability-accelerator"
 docs_link: "https://docs.aws.amazon.com/eks/latest/userguide/monitoring.html"
-last_validated: "2026-07-15"
+last_validated: "2026-08-18"

--- a/docusaurus/docs/solutions/frontend-slo-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/frontend-slo-monitoring/meta.yaml
@@ -9,7 +9,7 @@ signals: [metrics, traces]
 instrumentation: custom
 status: active
 time_to_value_minutes: 25
-last_validated: "2026-08-20"
+last_validated: "2026-05-20"
 iac_available: []
 partner_integrations: []
 accelerator_link: ""

--- a/docusaurus/docs/solutions/genai-observability/meta.yaml
+++ b/docusaurus/docs/solutions/genai-observability/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 45
 instrumentation: otel
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring.html"
-last_validated: "2026-08-17"
+last_validated: "2026-05-27"

--- a/docusaurus/docs/solutions/getting-started-with-observability/meta.yaml
+++ b/docusaurus/docs/solutions/getting-started-with-observability/meta.yaml
@@ -6,7 +6,7 @@ workload_type: [compute]
 backends: [cloudwatch]
 signals: [metrics, logs, traces]
 status: active
-last_validated: "2026-08-20"
+last_validated: "2026-05-20"
 partner_integrations: []
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/GettingStarted.html"

--- a/docusaurus/docs/solutions/hybrid-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/hybrid-monitoring/meta.yaml
@@ -13,5 +13,5 @@ iac_available: []
 partner_integrations: []
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent-on-Premise.html"
-last_validated: "2026-08-20"
+last_validated: "2024-09-30"
 related_events: []

--- a/docusaurus/docs/solutions/just-in-time-node-access/meta.yaml
+++ b/docusaurus/docs/solutions/just-in-time-node-access/meta.yaml
@@ -13,5 +13,5 @@ instrumentation: custom
 status: active
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-just-in-time-node-access.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 related_events: []

--- a/docusaurus/docs/solutions/kafka-ec2/meta.yaml
+++ b/docusaurus/docs/solutions/kafka-ec2/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 25
 instrumentation: cwagent
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-jmx.html"
-last_validated: "2026-06-01"
+last_validated: "2026-08-18"

--- a/docusaurus/docs/solutions/lambda-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/lambda-monitoring/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 10
 instrumentation: cwagent
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html"
-last_validated: "2026-07-01"
+last_validated: "2026-08-18"

--- a/docusaurus/docs/solutions/managed-grafana-setup/meta.yaml
+++ b/docusaurus/docs/solutions/managed-grafana-setup/meta.yaml
@@ -13,5 +13,5 @@ iac_available: [terraform]
 partner_integrations: []
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/grafana/latest/userguide/what-is-Amazon-Managed-Service-Grafana.html"
-last_validated: "2026-08-20"
+last_validated: "2025-04-01"
 related_events: []

--- a/docusaurus/docs/solutions/msk-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/msk-monitoring/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 20
 instrumentation: prometheus
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html"
-last_validated: "2026-08-17"
+last_validated: "2026-08-10"

--- a/docusaurus/docs/solutions/network-observability/meta.yaml
+++ b/docusaurus/docs/solutions/network-observability/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 30
 instrumentation: custom
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html"
-last_validated: "2026-08-17"
+last_validated: "2026-08-02"

--- a/docusaurus/docs/solutions/observability-adoption-guide/meta.yaml
+++ b/docusaurus/docs/solutions/observability-adoption-guide/meta.yaml
@@ -7,4 +7,4 @@ backends: [cloudwatch]
 signals: [metrics, logs, traces]
 status: active
 docs_link: ""
-last_validated: "2026-08-20"
+last_validated: "2026-02-12"

--- a/docusaurus/docs/solutions/observability-cost-management/meta.yaml
+++ b/docusaurus/docs/solutions/observability-cost-management/meta.yaml
@@ -9,7 +9,7 @@ signals: [metrics, logs]
 instrumentation: custom
 status: active
 time_to_value_minutes: 30
-last_validated: "2026-08-20"
+last_validated: "2026-07-21"
 iac_available: []
 partner_integrations: []
 accelerator_link: ""

--- a/docusaurus/docs/solutions/observability-maturity-model/meta.yaml
+++ b/docusaurus/docs/solutions/observability-maturity-model/meta.yaml
@@ -7,4 +7,4 @@ backends: [cloudwatch]
 signals: [metrics, logs, traces]
 status: active
 docs_link: ""
-last_validated: "2026-08-20"
+last_validated: "2024-09-30"

--- a/docusaurus/docs/solutions/observability-strategy/meta.yaml
+++ b/docusaurus/docs/solutions/observability-strategy/meta.yaml
@@ -7,4 +7,4 @@ backends: [cloudwatch]
 signals: [metrics, logs, traces]
 status: active
 docs_link: "https://docs.aws.amazon.com/whitepapers/latest/aws-caf-operations-perspective/observability.html"
-last_validated: "2026-08-20"
+last_validated: "2025-03-31"

--- a/docusaurus/docs/solutions/opensearch-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/opensearch-monitoring/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 20
 instrumentation: prometheus
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/monitoring.html"
-last_validated: "2026-08-17"
+last_validated: "2026-08-10"

--- a/docusaurus/docs/solutions/patch-and-node-management/meta.yaml
+++ b/docusaurus/docs/solutions/patch-and-node-management/meta.yaml
@@ -13,5 +13,5 @@ instrumentation: custom
 status: active
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/systems-manager/latest/userguide/what-is-systems-manager.html"
-last_validated: "2026-08-20"
+last_validated: "2026-05-27"
 related_events: []

--- a/docusaurus/docs/solutions/rds-aurora-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/rds-aurora-monitoring/meta.yaml
@@ -11,7 +11,6 @@ partner_integrations: []
 time_to_value_minutes: 15
 instrumentation: custom
 status: active
-featured: true
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html"
-last_validated: "2026-08-17"
+last_validated: "2026-05-20"

--- a/docusaurus/docs/solutions/rust-custom-metrics/meta.yaml
+++ b/docusaurus/docs/solutions/rust-custom-metrics/meta.yaml
@@ -9,7 +9,7 @@ signals: [metrics]
 instrumentation: custom
 status: active
 time_to_value_minutes: 20
-last_validated: "2026-08-20"
+last_validated: "2024-09-30"
 iac_available: []
 partner_integrations: []
 accelerator_link: ""

--- a/docusaurus/docs/solutions/s3-access-logs-security/meta.yaml
+++ b/docusaurus/docs/solutions/s3-access-logs-security/meta.yaml
@@ -6,7 +6,6 @@ workload_type: [security]
 backends: [cloudwatch]
 signals: [logs]
 status: active
-featured: true
-last_validated: "2026-08-18"
+last_validated: "2026-07-06"
 docs_link: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html
 related_events: [security]

--- a/docusaurus/docs/solutions/security-lake-cloudwatch/meta.yaml
+++ b/docusaurus/docs/solutions/security-lake-cloudwatch/meta.yaml
@@ -6,7 +6,6 @@ workload_type: [security]
 backends: [cloudwatch]
 signals: [logs]
 status: active
-featured: true
-last_validated: "2026-08-18"
+last_validated: "2026-04-24"
 docs_link: https://docs.aws.amazon.com/security-lake/latest/userguide/what-is-security-lake.html
 related_events: [security]

--- a/docusaurus/docs/solutions/waf-security-analysis/meta.yaml
+++ b/docusaurus/docs/solutions/waf-security-analysis/meta.yaml
@@ -6,7 +6,6 @@ workload_type: [security, network]
 backends: [cloudwatch]
 signals: [logs, metrics]
 status: active
-featured: true
-last_validated: "2026-08-18"
+last_validated: "2026-07-10"
 docs_link: https://docs.aws.amazon.com/waf/latest/developerguide/logging.html
 related_events: [security]

--- a/docusaurus/docs/solutions/workspaces-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/workspaces-monitoring/meta.yaml
@@ -9,7 +9,7 @@ signals: [metrics]
 instrumentation: prometheus
 status: active
 time_to_value_minutes: 30
-last_validated: "2026-08-20"
+last_validated: "2024-09-30"
 iac_available: []
 partner_integrations: []
 accelerator_link: ""

--- a/docusaurus/static/catalog.json
+++ b/docusaurus/static/catalog.json
@@ -1,510 +1,7 @@
 {
-  "generated_at": "2026-08-21T21:59:06.178709+00:00",
+  "generated_at": "2026-08-22T02:46:30.112530+00:00",
   "schema_version": "1.0",
   "solutions": [
-    {
-      "name": "CloudWatch Logs Security Best Practices",
-      "slug": "cloudwatch-logs-security",
-      "content_type": "guide",
-      "description": "Best practices for securing CloudWatch Logs with IAM policies, deletion protection, encryption, data protection, and auditing.",
-      "workload_type": [
-        "security"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "status": "active",
-      "featured": true,
-      "last_validated": "2026-08-18",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/security.html",
-      "related_events": [
-        "security"
-      ]
-    },
-    {
-      "name": "Querying Security Lake with CloudWatch",
-      "slug": "security-lake-cloudwatch",
-      "content_type": "guide",
-      "description": "Query historical Security Lake data alongside CloudWatch unified data store logs using Athena cross-catalog queries.",
-      "workload_type": [
-        "security"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "status": "active",
-      "featured": true,
-      "last_validated": "2026-08-18",
-      "docs_link": "https://docs.aws.amazon.com/security-lake/latest/userguide/what-is-security-lake.html",
-      "related_events": [
-        "security"
-      ]
-    },
-    {
-      "name": "S3 Access Logs for Security & Compliance",
-      "slug": "s3-access-logs-security",
-      "content_type": "guide",
-      "description": "Use S3 server access logs with CloudWatch for security monitoring, compliance evidence, and operational auditing.",
-      "workload_type": [
-        "security"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "status": "active",
-      "featured": true,
-      "last_validated": "2026-08-18",
-      "docs_link": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html",
-      "related_events": [
-        "security"
-      ]
-    },
-    {
-      "name": "WAF Security Analysis with CloudWatch",
-      "slug": "waf-security-analysis",
-      "content_type": "guide",
-      "description": "Analyze AWS WAF logs with CloudWatch Logs Insights, metric filters, and Contributor Insights for threat detection and response.",
-      "workload_type": [
-        "security",
-        "network"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs",
-        "metrics"
-      ],
-      "status": "active",
-      "featured": true,
-      "last_validated": "2026-08-18",
-      "docs_link": "https://docs.aws.amazon.com/waf/latest/developerguide/logging.html",
-      "related_events": [
-        "security"
-      ]
-    },
-    {
-      "name": ".NET Application Monitoring",
-      "slug": "dotnet-application-monitoring",
-      "content_type": "solution",
-      "description": "End-to-end observability for .NET applications using OpenTelemetry and CloudWatch-native instrumentation paths",
-      "workload_type": [
-        "applications"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "logs",
-        "traces"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 30,
-      "instrumentation": "otel",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "Amazon MSK Monitoring",
-      "slug": "msk-monitoring",
-      "content_type": "solution",
-      "description": "Monitor Amazon MSK (Managed Streaming for Apache Kafka) clusters using Open Monitoring with Prometheus, AWS Managed Collector, and CloudWatch",
-      "workload_type": [
-        "data-streaming"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch",
-        "amp",
-        "amg"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 20,
-      "instrumentation": "prometheus",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "Amazon OpenSearch Service Monitoring",
-      "slug": "opensearch-monitoring",
-      "content_type": "solution",
-      "description": "Monitor Amazon OpenSearch Service domains using AWS Managed Collector with Prometheus metrics and CloudWatch",
-      "workload_type": [
-        "data-streaming"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch",
-        "amp",
-        "amg"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 20,
-      "instrumentation": "prometheus",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/monitoring.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "Coding Agents Observability",
-      "slug": "coding-agents-observability",
-      "content_type": "solution",
-      "description": "OTel-based telemetry for Claude Code, OpenAI Codex, and GitHub Copilot fleets \u2014 token usage, cost tracking, and team attribution",
-      "workload_type": [
-        "ai-ml"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch",
-        "amg"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 30,
-      "instrumentation": "otel",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "ECS Monitoring",
-      "slug": "ecs-monitoring",
-      "content_type": "solution",
-      "description": "Monitor Amazon ECS workloads on EC2 and Fargate using Container Insights and ADOT with AMP/AMG backends",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "ecs",
-        "fargate"
-      ],
-      "backends": [
-        "cloudwatch",
-        "amp",
-        "amg",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "logs",
-        "traces"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 25,
-      "instrumentation": "adot",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "EKS Monitoring with CloudWatch Container Insights",
-      "slug": "eks-container-insights",
-      "content_type": "solution",
-      "description": "Collect metrics, logs, and traces from Amazon EKS clusters using CloudWatch Container Insights with the CloudWatch agent and Fluent Bit",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "eks"
-      ],
-      "backends": [
-        "cloudwatch",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "logs",
-        "traces"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 15,
-      "instrumentation": "cwagent",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "GenAI Workload Observability",
-      "slug": "genai-observability",
-      "content_type": "solution",
-      "description": "Bedrock and SageMaker model invocation monitoring with token/cost tracking, agent traces, and LLM performance dashboards",
-      "workload_type": [
-        "ai-ml"
-      ],
-      "compute_platform": [
-        "sagemaker"
-      ],
-      "backends": [
-        "cloudwatch",
-        "amg"
-      ],
-      "signals": [
-        "metrics",
-        "logs",
-        "traces"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 45,
-      "instrumentation": "otel",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "Network Observability",
-      "slug": "network-observability",
-      "content_type": "solution",
-      "description": "VPC Flow Logs, Network Flow Monitor, Internet Monitor, and Synthetic Monitor for end-to-end AWS network visibility",
-      "workload_type": [
-        "network"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 30,
-      "instrumentation": "custom",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "RDS & Aurora Monitoring",
-      "slug": "rds-aurora-monitoring",
-      "content_type": "solution",
-      "description": "Monitor Amazon RDS and Aurora databases with CloudWatch metrics, Performance Insights, Database Insights, and Enhanced Monitoring",
-      "workload_type": [
-        "data-streaming"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 15,
-      "instrumentation": "custom",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html",
-      "last_validated": "2026-08-17"
-    },
-    {
-      "name": "EKS Infrastructure Monitoring",
-      "slug": "eks-infrastructure",
-      "content_type": "solution",
-      "description": "End-to-end infrastructure monitoring for Amazon EKS clusters using Prometheus, Grafana, and AWS managed services",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "eks"
-      ],
-      "backends": [
-        "amp",
-        "amg",
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [
-        "terraform"
-      ],
-      "partner_integrations": [],
-      "time_to_value_minutes": 30,
-      "instrumentation": "otel",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "https://github.com/aws-observability/terraform-aws-observability-accelerator",
-      "docs_link": "https://docs.aws.amazon.com/eks/latest/userguide/monitoring.html",
-      "last_validated": "2026-07-15"
-    },
-    {
-      "name": "Lambda Monitoring",
-      "slug": "lambda-monitoring",
-      "content_type": "solution",
-      "description": "Comprehensive AWS Lambda monitoring with CloudWatch native metrics, X-Ray tracing, and Lambda Insights",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "lambda"
-      ],
-      "backends": [
-        "cloudwatch",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "traces",
-        "logs"
-      ],
-      "iac_available": [
-        "cdk",
-        "terraform",
-        "cloudformation"
-      ],
-      "partner_integrations": [],
-      "time_to_value_minutes": 10,
-      "instrumentation": "cwagent",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html",
-      "last_validated": "2026-07-01"
-    },
-    {
-      "name": "EKS Java Application Monitoring",
-      "slug": "eks-application-signals",
-      "content_type": "solution",
-      "description": "Application-level monitoring for Java/JVM workloads on EKS using CloudWatch Application Signals and OpenTelemetry",
-      "workload_type": [
-        "compute",
-        "applications"
-      ],
-      "compute_platform": [
-        "eks"
-      ],
-      "backends": [
-        "cloudwatch",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "traces",
-        "logs"
-      ],
-      "iac_available": [
-        "cdk",
-        "terraform"
-      ],
-      "partner_integrations": [],
-      "time_to_value_minutes": 20,
-      "instrumentation": "otel",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html",
-      "last_validated": "2026-06-20"
-    },
-    {
-      "name": "Kafka on EC2 Monitoring",
-      "slug": "kafka-ec2",
-      "content_type": "solution",
-      "description": "Monitor self-managed Apache Kafka clusters on EC2 using CloudWatch Agent JMX plugin for broker and consumer metrics",
-      "workload_type": [
-        "data-streaming",
-        "compute"
-      ],
-      "compute_platform": [
-        "ec2"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 25,
-      "instrumentation": "cwagent",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-jmx.html",
-      "last_validated": "2026-06-01"
-    },
-    {
-      "name": "EC2 NGINX Monitoring",
-      "slug": "ec2-nginx",
-      "content_type": "solution",
-      "description": "Monitor NGINX web servers on EC2 using CloudWatch Agent with StatsD and custom metrics",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "ec2"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 15,
-      "instrumentation": "cwagent",
-      "status": "active",
-      "featured": true,
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html",
-      "last_validated": "2026-05-10"
-    },
     {
       "name": "Alarms and Alerting",
       "slug": "cloudwatch-alarms-alerting",
@@ -608,22 +105,224 @@
       ]
     },
     {
-      "name": "ADOT Collector at Scale",
-      "slug": "adot-at-scale",
+      "name": "EC2 NGINX Monitoring",
+      "slug": "ec2-nginx",
       "content_type": "solution",
-      "description": "Production deployment of the AWS Distro for OpenTelemetry Collector: modes, scaling, resource sizing, pipeline design, and Java Spring instrumentation",
+      "description": "Monitor NGINX web servers on EC2 using CloudWatch Agent with StatsD and custom metrics",
+      "workload_type": [
+        "compute"
+      ],
+      "compute_platform": [
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 15,
+      "instrumentation": "cwagent",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html",
+      "last_validated": "2026-08-18"
+    },
+    {
+      "name": "EKS Infrastructure Monitoring",
+      "slug": "eks-infrastructure",
+      "content_type": "solution",
+      "description": "End-to-end infrastructure monitoring for Amazon EKS clusters using Prometheus, Grafana, and AWS managed services",
+      "workload_type": [
+        "compute"
+      ],
+      "compute_platform": [
+        "eks"
+      ],
+      "backends": [
+        "amp",
+        "amg",
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [
+        "terraform"
+      ],
+      "partner_integrations": [],
+      "time_to_value_minutes": 30,
+      "instrumentation": "otel",
+      "status": "active",
+      "accelerator_link": "https://github.com/aws-observability/terraform-aws-observability-accelerator",
+      "docs_link": "https://docs.aws.amazon.com/eks/latest/userguide/monitoring.html",
+      "last_validated": "2026-08-18"
+    },
+    {
+      "name": "EKS Java Application Monitoring",
+      "slug": "eks-application-signals",
+      "content_type": "solution",
+      "description": "Application-level monitoring for Java/JVM workloads on EKS using CloudWatch Application Signals and OpenTelemetry",
       "workload_type": [
         "compute",
         "applications"
       ],
       "compute_platform": [
-        "eks",
-        "ecs",
-        "ec2"
+        "eks"
       ],
       "backends": [
         "cloudwatch",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "traces",
+        "logs"
+      ],
+      "iac_available": [
+        "cdk",
+        "terraform"
+      ],
+      "partner_integrations": [],
+      "time_to_value_minutes": 20,
+      "instrumentation": "otel",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html",
+      "last_validated": "2026-08-18"
+    },
+    {
+      "name": "Kafka on EC2 Monitoring",
+      "slug": "kafka-ec2",
+      "content_type": "solution",
+      "description": "Monitor self-managed Apache Kafka clusters on EC2 using CloudWatch Agent JMX plugin for broker and consumer metrics",
+      "workload_type": [
+        "data-streaming",
+        "compute"
+      ],
+      "compute_platform": [
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 25,
+      "instrumentation": "cwagent",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-jmx.html",
+      "last_validated": "2026-08-18"
+    },
+    {
+      "name": "Lambda Monitoring",
+      "slug": "lambda-monitoring",
+      "content_type": "solution",
+      "description": "Comprehensive AWS Lambda monitoring with CloudWatch native metrics, X-Ray tracing, and Lambda Insights",
+      "workload_type": [
+        "compute"
+      ],
+      "compute_platform": [
+        "lambda"
+      ],
+      "backends": [
+        "cloudwatch",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "traces",
+        "logs"
+      ],
+      "iac_available": [
+        "cdk",
+        "terraform",
+        "cloudformation"
+      ],
+      "partner_integrations": [],
+      "time_to_value_minutes": 10,
+      "instrumentation": "cwagent",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html",
+      "last_validated": "2026-08-18"
+    },
+    {
+      "name": "Amazon MSK Monitoring",
+      "slug": "msk-monitoring",
+      "content_type": "solution",
+      "description": "Monitor Amazon MSK (Managed Streaming for Apache Kafka) clusters using Open Monitoring with Prometheus, AWS Managed Collector, and CloudWatch",
+      "workload_type": [
+        "data-streaming"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch",
         "amp",
+        "amg"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 20,
+      "instrumentation": "prometheus",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html",
+      "last_validated": "2026-08-10"
+    },
+    {
+      "name": "Amazon OpenSearch Service Monitoring",
+      "slug": "opensearch-monitoring",
+      "content_type": "solution",
+      "description": "Monitor Amazon OpenSearch Service domains using AWS Managed Collector with Prometheus metrics and CloudWatch",
+      "workload_type": [
+        "data-streaming"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch",
+        "amp",
+        "amg"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 20,
+      "instrumentation": "prometheus",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/monitoring.html",
+      "last_validated": "2026-08-10"
+    },
+    {
+      "name": "EKS Monitoring with CloudWatch Container Insights",
+      "slug": "eks-container-insights",
+      "content_type": "solution",
+      "description": "Collect metrics, logs, and traces from Amazon EKS clusters using CloudWatch Container Insights with the CloudWatch agent and Fluent Bit",
+      "workload_type": [
+        "compute"
+      ],
+      "compute_platform": [
+        "eks"
+      ],
+      "backends": [
+        "cloudwatch",
         "xray"
       ],
       "signals": [
@@ -631,15 +330,166 @@
         "logs",
         "traces"
       ],
-      "instrumentation": "adot",
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 15,
+      "instrumentation": "cwagent",
       "status": "active",
-      "time_to_value_minutes": 45,
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html",
+      "last_validated": "2026-08-10"
+    },
+    {
+      "name": "Network Observability",
+      "slug": "network-observability",
+      "content_type": "solution",
+      "description": "VPC Flow Logs, Network Flow Monitor, Internet Monitor, and Synthetic Monitor for end-to-end AWS network visibility",
+      "workload_type": [
+        "network"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 30,
+      "instrumentation": "custom",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html",
+      "last_validated": "2026-08-02"
+    },
+    {
+      "name": "Observability Cost Management",
+      "slug": "observability-cost-management",
+      "content_type": "solution",
+      "description": "Gain visibility into CloudWatch, AMP, AMG, and X-Ray spend using CUR dashboards, reduce CloudWatch costs, and attribute EKS GPU expenses with Kubecost.",
+      "workload_type": [
+        "compute"
+      ],
+      "compute_platform": [
+        "eks",
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch",
+        "amp",
+        "amg",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "instrumentation": "custom",
+      "status": "active",
+      "time_to_value_minutes": 30,
+      "last_validated": "2026-07-21",
       "iac_available": [],
       "partner_integrations": [],
       "accelerator_link": "",
-      "docs_link": "https://aws-otel.github.io/docs/getting-started/collector",
-      "last_validated": "2026-08-20",
-      "related_events": []
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_billing.html",
+      "related_events": [
+        "cloudwatch",
+        "metrics"
+      ]
+    },
+    {
+      "name": "CloudWatch Logs Analysis",
+      "slug": "cloudwatch-logs-analysis",
+      "content_type": "guide",
+      "description": "Guidance on structured logging, log levels, filtering, Logs Insights query patterns, Contributor Insights, and data protection policies.",
+      "workload_type": [
+        "applications"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "status": "active",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html",
+      "last_validated": "2026-07-10",
+      "related_events": [
+        "logs",
+        "cloudwatch"
+      ]
+    },
+    {
+      "name": "WAF Security Analysis with CloudWatch",
+      "slug": "waf-security-analysis",
+      "content_type": "guide",
+      "description": "Analyze AWS WAF logs with CloudWatch Logs Insights, metric filters, and Contributor Insights for threat detection and response.",
+      "workload_type": [
+        "security",
+        "network"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs",
+        "metrics"
+      ],
+      "status": "active",
+      "last_validated": "2026-07-10",
+      "docs_link": "https://docs.aws.amazon.com/waf/latest/developerguide/logging.html",
+      "related_events": [
+        "security"
+      ]
+    },
+    {
+      "name": "S3 Access Logs for Security & Compliance",
+      "slug": "s3-access-logs-security",
+      "content_type": "guide",
+      "description": "Use S3 server access logs with CloudWatch for security monitoring, compliance evidence, and operational auditing.",
+      "workload_type": [
+        "security"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "status": "active",
+      "last_validated": "2026-07-06",
+      "docs_link": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html",
+      "related_events": [
+        "security"
+      ]
+    },
+    {
+      "name": "Coding Agents Observability",
+      "slug": "coding-agents-observability",
+      "content_type": "solution",
+      "description": "OTel-based telemetry for Claude Code, OpenAI Codex, and GitHub Copilot fleets \u2014 token usage, cost tracking, and team attribution",
+      "workload_type": [
+        "ai-ml"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch",
+        "amg"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 30,
+      "instrumentation": "otel",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "",
+      "last_validated": "2026-06-22"
     },
     {
       "name": "AI Workload Audit and Monitoring",
@@ -659,7 +509,7 @@
         "traces"
       ],
       "status": "active",
-      "last_validated": "2026-08-20",
+      "last_validated": "2026-05-27",
       "partner_integrations": [],
       "accelerator_link": "",
       "docs_link": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html",
@@ -692,7 +542,7 @@
       "status": "active",
       "accelerator_link": "",
       "docs_link": "https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html",
-      "last_validated": "2026-08-20",
+      "last_validated": "2026-05-27",
       "related_events": [
         "security"
       ]
@@ -713,8 +563,475 @@
       ],
       "status": "active",
       "docs_link": "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html",
-      "last_validated": "2026-08-20",
+      "last_validated": "2026-05-27",
       "related_events": []
+    },
+    {
+      "name": "CloudTrail Cost Optimization",
+      "slug": "cloudtrail-cost-optimization",
+      "content_type": "guide",
+      "description": "Estimate and control AWS CloudTrail costs: data event cost estimation, CloudWatch Logs ingestion pricing, log transformation, and CloudTrail Lake.",
+      "workload_type": [
+        "operations"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-trail-pricing.html",
+      "last_validated": "2026-05-27",
+      "related_events": []
+    },
+    {
+      "name": "CloudTrail Monitoring",
+      "slug": "cloudtrail-monitoring",
+      "content_type": "solution",
+      "description": "Configure and operate AWS CloudTrail trails for management events, data events, and network activity events using advanced event selectors.",
+      "workload_type": [
+        "operations",
+        "security"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 30,
+      "instrumentation": "custom",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html",
+      "last_validated": "2026-05-27",
+      "related_events": []
+    },
+    {
+      "name": "CloudTrail Security Forensics",
+      "slug": "cloudtrail-security-forensics",
+      "content_type": "guide",
+      "description": "Security incident response and forensic analysis with CloudTrail: critical event fields, investigation patterns, and security dashboards.",
+      "workload_type": [
+        "security",
+        "operations"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html",
+      "last_validated": "2026-05-27",
+      "related_events": [
+        "security"
+      ]
+    },
+    {
+      "name": "Control Tower Landing Zone",
+      "slug": "control-tower-landing-zone",
+      "content_type": "guide",
+      "description": "Lifecycle guidance for AWS Control Tower landing zones: planning, customising, operating, enabling in existing organisations, and upgrading to 4.0.",
+      "workload_type": [
+        "operations"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "status": "active",
+      "docs_link": "https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html",
+      "last_validated": "2026-05-27"
+    },
+    {
+      "name": "GenAI Workload Observability",
+      "slug": "genai-observability",
+      "content_type": "solution",
+      "description": "Bedrock and SageMaker model invocation monitoring with token/cost tracking, agent traces, and LLM performance dashboards",
+      "workload_type": [
+        "ai-ml"
+      ],
+      "compute_platform": [
+        "sagemaker"
+      ],
+      "backends": [
+        "cloudwatch",
+        "amg"
+      ],
+      "signals": [
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 45,
+      "instrumentation": "otel",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring.html",
+      "last_validated": "2026-05-27"
+    },
+    {
+      "name": "Just-in-Time Node Access",
+      "slug": "just-in-time-node-access",
+      "content_type": "solution",
+      "description": "Approval-based temporary access to managed nodes with Cedar policies, EventBridge integration, and Infrastructure-as-Code enablement",
+      "workload_type": [
+        "operations",
+        "security"
+      ],
+      "compute_platform": [
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "iac_available": [
+        "cloudformation"
+      ],
+      "partner_integrations": [],
+      "time_to_value_minutes": 30,
+      "instrumentation": "custom",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-just-in-time-node-access.html",
+      "last_validated": "2026-05-27",
+      "related_events": []
+    },
+    {
+      "name": "Patch and Node Management",
+      "slug": "patch-and-node-management",
+      "content_type": "solution",
+      "description": "Fleet management with AWS Systems Manager: patch baselines, tag-based patching, SSM Agent lifecycle, session management, automation, and compliance reporting",
+      "workload_type": [
+        "operations"
+      ],
+      "compute_platform": [
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs",
+        "metrics"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 40,
+      "instrumentation": "custom",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/systems-manager/latest/userguide/what-is-systems-manager.html",
+      "last_validated": "2026-05-27",
+      "related_events": []
+    },
+    {
+      "name": "CloudWatch Dashboards",
+      "slug": "cloudwatch-dashboards",
+      "content_type": "guide",
+      "description": "Design effective CloudWatch dashboards with the right layout, widgets, and stories to reduce MTTR and drive data-driven decisions.",
+      "workload_type": [
+        "applications"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "status": "active",
+      "last_validated": "2026-05-20",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html",
+      "related_events": [
+        "cloudwatch",
+        "metrics"
+      ]
+    },
+    {
+      "name": "CloudWatch Metrics and EMF",
+      "slug": "cloudwatch-metrics",
+      "content_type": "guide",
+      "description": "Metrics guidance covering dimensions, cardinality, high-resolution metrics, vended vs custom metrics, and Embedded Metric Format for log-derived metrics.",
+      "workload_type": [
+        "applications"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics"
+      ],
+      "status": "active",
+      "last_validated": "2026-05-20",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html",
+      "related_events": [
+        "cloudwatch",
+        "metrics"
+      ]
+    },
+    {
+      "name": "Distributed Tracing",
+      "slug": "distributed-tracing",
+      "content_type": "guide",
+      "description": "Guidance on distributed tracing with AWS X-Ray and OpenTelemetry, including sampling strategy and choosing a tracing agent.",
+      "workload_type": [
+        "applications"
+      ],
+      "backends": [
+        "xray",
+        "cloudwatch"
+      ],
+      "signals": [
+        "traces"
+      ],
+      "status": "active",
+      "docs_link": "https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html",
+      "last_validated": "2026-05-20",
+      "related_events": [
+        "apm"
+      ]
+    },
+    {
+      "name": "Frontend and SLO Monitoring",
+      "slug": "frontend-slo-monitoring",
+      "content_type": "solution",
+      "description": "Digital experience monitoring with CloudWatch RUM, Synthetics canaries, and Application Signals SLOs for frontend performance and reliability.",
+      "workload_type": [
+        "applications"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "traces"
+      ],
+      "instrumentation": "custom",
+      "status": "active",
+      "time_to_value_minutes": 25,
+      "last_validated": "2026-05-20",
+      "iac_available": [],
+      "partner_integrations": [],
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM.html",
+      "related_events": [
+        "apm",
+        "cloudwatch"
+      ]
+    },
+    {
+      "name": "Getting Started with Observability",
+      "slug": "getting-started-with-observability",
+      "content_type": "guide",
+      "description": "An onboarding path for CloudWatch observability: account setup, unified data store, agents and collectors, then dashboards and alerts.",
+      "workload_type": [
+        "compute"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "status": "active",
+      "last_validated": "2026-05-20",
+      "partner_integrations": [],
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/GettingStarted.html",
+      "related_events": [
+        "cloudwatch"
+      ]
+    },
+    {
+      "name": "RDS & Aurora Monitoring",
+      "slug": "rds-aurora-monitoring",
+      "content_type": "solution",
+      "description": "Monitor Amazon RDS and Aurora databases with CloudWatch metrics, Performance Insights, Database Insights, and Enhanced Monitoring",
+      "workload_type": [
+        "data-streaming"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 15,
+      "instrumentation": "custom",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html",
+      "last_validated": "2026-05-20"
+    },
+    {
+      "name": "Querying Security Lake with CloudWatch",
+      "slug": "security-lake-cloudwatch",
+      "content_type": "guide",
+      "description": "Query historical Security Lake data alongside CloudWatch unified data store logs using Athena cross-catalog queries.",
+      "workload_type": [
+        "security"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "status": "active",
+      "last_validated": "2026-04-24",
+      "docs_link": "https://docs.aws.amazon.com/security-lake/latest/userguide/what-is-security-lake.html",
+      "related_events": [
+        "security"
+      ]
+    },
+    {
+      "name": "CloudWatch Agent Configuration",
+      "slug": "cloudwatch-agent-configuration",
+      "content_type": "guide",
+      "description": "Guidance on CloudWatch agent configuration, deployment via Systems Manager, and when to use the agent versus ADOT.",
+      "workload_type": [
+        "compute"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "status": "active",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html",
+      "last_validated": "2026-02-20",
+      "related_events": [
+        "cloudwatch",
+        "metrics"
+      ]
+    },
+    {
+      "name": "Observability Adoption Guide",
+      "slug": "observability-adoption-guide",
+      "content_type": "guide",
+      "description": "Staged adoption framework for growing organizations covering reactive, foundational, and integrated observability plus anti-patterns to avoid.",
+      "workload_type": [
+        "applications"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "status": "active",
+      "docs_link": "",
+      "last_validated": "2026-02-12"
+    },
+    {
+      "name": "CloudWatch Logs Security Best Practices",
+      "slug": "cloudwatch-logs-security",
+      "content_type": "guide",
+      "description": "Best practices for securing CloudWatch Logs with IAM policies, deletion protection, encryption, data protection, and auditing.",
+      "workload_type": [
+        "security"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "logs"
+      ],
+      "status": "active",
+      "last_validated": "2026-01-12",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/security.html",
+      "related_events": [
+        "security"
+      ]
+    },
+    {
+      "name": ".NET Application Monitoring",
+      "slug": "dotnet-application-monitoring",
+      "content_type": "solution",
+      "description": "End-to-end observability for .NET applications using OpenTelemetry and CloudWatch-native instrumentation paths",
+      "workload_type": [
+        "applications"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 30,
+      "instrumentation": "otel",
+      "status": "active",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html",
+      "last_validated": "2025-05-29"
+    },
+    {
+      "name": "Cross-Account Observability",
+      "slug": "cross-account-observability",
+      "content_type": "solution",
+      "description": "Centralize metrics, logs, and traces across AWS accounts using CloudWatch cross-account observability and AMP cross-account scraping.",
+      "workload_type": [
+        "compute",
+        "operations"
+      ],
+      "compute_platform": [],
+      "backends": [
+        "cloudwatch",
+        "amp",
+        "amg",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "instrumentation": "custom",
+      "status": "active",
+      "time_to_value_minutes": 40,
+      "last_validated": "2025-04-23",
+      "iac_available": [],
+      "partner_integrations": [],
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html",
+      "related_events": [
+        "cloudwatch",
+        "metrics"
+      ]
     },
     {
       "name": "Amazon Managed Grafana Setup",
@@ -742,7 +1059,61 @@
       "partner_integrations": [],
       "accelerator_link": "",
       "docs_link": "https://docs.aws.amazon.com/grafana/latest/userguide/what-is-Amazon-Managed-Service-Grafana.html",
-      "last_validated": "2026-08-20",
+      "last_validated": "2025-04-01",
+      "related_events": []
+    },
+    {
+      "name": "Observability Strategy",
+      "slug": "observability-strategy",
+      "content_type": "guide",
+      "description": "Strategic guidance for IT leaders on tying observability to business outcomes, ROI framing, KPI selection, and SLA measurement with percentiles.",
+      "workload_type": [
+        "applications"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "status": "active",
+      "docs_link": "https://docs.aws.amazon.com/whitepapers/latest/aws-caf-operations-perspective/observability.html",
+      "last_validated": "2025-03-31"
+    },
+    {
+      "name": "ADOT Collector at Scale",
+      "slug": "adot-at-scale",
+      "content_type": "solution",
+      "description": "Production deployment of the AWS Distro for OpenTelemetry Collector: modes, scaling, resource sizing, pipeline design, and Java Spring instrumentation",
+      "workload_type": [
+        "compute",
+        "applications"
+      ],
+      "compute_platform": [
+        "eks",
+        "ecs",
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch",
+        "amp",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "instrumentation": "adot",
+      "status": "active",
+      "time_to_value_minutes": 45,
+      "iac_available": [],
+      "partner_integrations": [],
+      "accelerator_link": "",
+      "docs_link": "https://aws-otel.github.io/docs/getting-started/collector",
+      "last_validated": "2024-09-30",
       "related_events": []
     },
     {
@@ -766,7 +1137,7 @@
       "instrumentation": "prometheus",
       "status": "active",
       "time_to_value_minutes": 30,
-      "last_validated": "2026-08-20",
+      "last_validated": "2024-09-30",
       "iac_available": [],
       "partner_integrations": [],
       "accelerator_link": "",
@@ -803,219 +1174,8 @@
       "partner_integrations": [],
       "accelerator_link": "",
       "docs_link": "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-manage-view-web-log-files.html",
-      "last_validated": "2026-08-20",
+      "last_validated": "2024-09-30",
       "related_events": []
-    },
-    {
-      "name": "CloudTrail Cost Optimization",
-      "slug": "cloudtrail-cost-optimization",
-      "content_type": "guide",
-      "description": "Estimate and control AWS CloudTrail costs: data event cost estimation, CloudWatch Logs ingestion pricing, log transformation, and CloudTrail Lake.",
-      "workload_type": [
-        "operations"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-trail-pricing.html",
-      "last_validated": "2026-08-20",
-      "related_events": []
-    },
-    {
-      "name": "CloudTrail Monitoring",
-      "slug": "cloudtrail-monitoring",
-      "content_type": "solution",
-      "description": "Configure and operate AWS CloudTrail trails for management events, data events, and network activity events using advanced event selectors.",
-      "workload_type": [
-        "operations",
-        "security"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 30,
-      "instrumentation": "custom",
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html",
-      "last_validated": "2026-08-20",
-      "related_events": []
-    },
-    {
-      "name": "CloudTrail Security Forensics",
-      "slug": "cloudtrail-security-forensics",
-      "content_type": "guide",
-      "description": "Security incident response and forensic analysis with CloudTrail: critical event fields, investigation patterns, and security dashboards.",
-      "workload_type": [
-        "security",
-        "operations"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html",
-      "last_validated": "2026-08-20",
-      "related_events": [
-        "security"
-      ]
-    },
-    {
-      "name": "CloudWatch Agent Configuration",
-      "slug": "cloudwatch-agent-configuration",
-      "content_type": "guide",
-      "description": "Guidance on CloudWatch agent configuration, deployment via Systems Manager, and when to use the agent versus ADOT.",
-      "workload_type": [
-        "compute"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "status": "active",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html",
-      "last_validated": "2026-08-20",
-      "related_events": [
-        "cloudwatch",
-        "metrics"
-      ]
-    },
-    {
-      "name": "CloudWatch Dashboards",
-      "slug": "cloudwatch-dashboards",
-      "content_type": "guide",
-      "description": "Design effective CloudWatch dashboards with the right layout, widgets, and stories to reduce MTTR and drive data-driven decisions.",
-      "workload_type": [
-        "applications"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "status": "active",
-      "last_validated": "2026-08-20",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html",
-      "related_events": [
-        "cloudwatch",
-        "metrics"
-      ]
-    },
-    {
-      "name": "CloudWatch Logs Analysis",
-      "slug": "cloudwatch-logs-analysis",
-      "content_type": "guide",
-      "description": "Guidance on structured logging, log levels, filtering, Logs Insights query patterns, Contributor Insights, and data protection policies.",
-      "workload_type": [
-        "applications"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "status": "active",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html",
-      "last_validated": "2026-08-20",
-      "related_events": [
-        "logs",
-        "cloudwatch"
-      ]
-    },
-    {
-      "name": "CloudWatch Metrics and EMF",
-      "slug": "cloudwatch-metrics",
-      "content_type": "guide",
-      "description": "Metrics guidance covering dimensions, cardinality, high-resolution metrics, vended vs custom metrics, and Embedded Metric Format for log-derived metrics.",
-      "workload_type": [
-        "applications"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics"
-      ],
-      "status": "active",
-      "last_validated": "2026-08-20",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html",
-      "related_events": [
-        "cloudwatch",
-        "metrics"
-      ]
-    },
-    {
-      "name": "Control Tower Landing Zone",
-      "slug": "control-tower-landing-zone",
-      "content_type": "guide",
-      "description": "Lifecycle guidance for AWS Control Tower landing zones: planning, customising, operating, enabling in existing organisations, and upgrading to 4.0.",
-      "workload_type": [
-        "operations"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "status": "active",
-      "docs_link": "https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html",
-      "last_validated": "2026-08-20"
-    },
-    {
-      "name": "Cross-Account Observability",
-      "slug": "cross-account-observability",
-      "content_type": "solution",
-      "description": "Centralize metrics, logs, and traces across AWS accounts using CloudWatch cross-account observability and AMP cross-account scraping.",
-      "workload_type": [
-        "compute",
-        "operations"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch",
-        "amp",
-        "amg",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "logs",
-        "traces"
-      ],
-      "instrumentation": "custom",
-      "status": "active",
-      "time_to_value_minutes": 40,
-      "last_validated": "2026-08-20",
-      "iac_available": [],
-      "partner_integrations": [],
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html",
-      "related_events": [
-        "cloudwatch",
-        "metrics"
-      ]
     },
     {
       "name": "Databricks Monitoring",
@@ -1044,85 +1204,40 @@
       ],
       "accelerator_link": "",
       "docs_link": "",
-      "last_validated": "2026-08-20",
+      "last_validated": "2024-09-30",
       "related_events": []
     },
     {
-      "name": "Distributed Tracing",
-      "slug": "distributed-tracing",
-      "content_type": "guide",
-      "description": "Guidance on distributed tracing with AWS X-Ray and OpenTelemetry, including sampling strategy and choosing a tracing agent.",
-      "workload_type": [
-        "applications"
-      ],
-      "backends": [
-        "xray",
-        "cloudwatch"
-      ],
-      "signals": [
-        "traces"
-      ],
-      "status": "active",
-      "docs_link": "https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html",
-      "last_validated": "2026-08-20",
-      "related_events": [
-        "apm"
-      ]
-    },
-    {
-      "name": "Frontend and SLO Monitoring",
-      "slug": "frontend-slo-monitoring",
+      "name": "ECS Monitoring",
+      "slug": "ecs-monitoring",
       "content_type": "solution",
-      "description": "Digital experience monitoring with CloudWatch RUM, Synthetics canaries, and Application Signals SLOs for frontend performance and reliability.",
-      "workload_type": [
-        "applications"
-      ],
-      "compute_platform": [],
-      "backends": [
-        "cloudwatch",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "traces"
-      ],
-      "instrumentation": "custom",
-      "status": "active",
-      "time_to_value_minutes": 25,
-      "last_validated": "2026-08-20",
-      "iac_available": [],
-      "partner_integrations": [],
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM.html",
-      "related_events": [
-        "apm",
-        "cloudwatch"
-      ]
-    },
-    {
-      "name": "Getting Started with Observability",
-      "slug": "getting-started-with-observability",
-      "content_type": "guide",
-      "description": "An onboarding path for CloudWatch observability: account setup, unified data store, agents and collectors, then dashboards and alerts.",
+      "description": "Monitor Amazon ECS workloads on EC2 and Fargate using Container Insights and ADOT with AMP/AMG backends",
       "workload_type": [
         "compute"
       ],
+      "compute_platform": [
+        "ecs",
+        "fargate"
+      ],
       "backends": [
-        "cloudwatch"
+        "cloudwatch",
+        "amp",
+        "amg",
+        "xray"
       ],
       "signals": [
         "metrics",
         "logs",
         "traces"
       ],
-      "status": "active",
-      "last_validated": "2026-08-20",
+      "iac_available": [],
       "partner_integrations": [],
+      "time_to_value_minutes": 25,
+      "instrumentation": "adot",
+      "status": "active",
       "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/GettingStarted.html",
-      "related_events": [
-        "cloudwatch"
-      ]
+      "docs_link": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html",
+      "last_validated": "2024-09-30"
     },
     {
       "name": "Hybrid and Multicloud Monitoring",
@@ -1151,93 +1266,8 @@
       "partner_integrations": [],
       "accelerator_link": "",
       "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent-on-Premise.html",
-      "last_validated": "2026-08-20",
+      "last_validated": "2024-09-30",
       "related_events": []
-    },
-    {
-      "name": "Just-in-Time Node Access",
-      "slug": "just-in-time-node-access",
-      "content_type": "solution",
-      "description": "Approval-based temporary access to managed nodes with Cedar policies, EventBridge integration, and Infrastructure-as-Code enablement",
-      "workload_type": [
-        "operations",
-        "security"
-      ],
-      "compute_platform": [
-        "ec2"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs"
-      ],
-      "iac_available": [
-        "cloudformation"
-      ],
-      "partner_integrations": [],
-      "time_to_value_minutes": 30,
-      "instrumentation": "custom",
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-just-in-time-node-access.html",
-      "last_validated": "2026-08-20",
-      "related_events": []
-    },
-    {
-      "name": "Observability Adoption Guide",
-      "slug": "observability-adoption-guide",
-      "content_type": "guide",
-      "description": "Staged adoption framework for growing organizations covering reactive, foundational, and integrated observability plus anti-patterns to avoid.",
-      "workload_type": [
-        "applications"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs",
-        "traces"
-      ],
-      "status": "active",
-      "docs_link": "",
-      "last_validated": "2026-08-20"
-    },
-    {
-      "name": "Observability Cost Management",
-      "slug": "observability-cost-management",
-      "content_type": "solution",
-      "description": "Gain visibility into CloudWatch, AMP, AMG, and X-Ray spend using CUR dashboards, reduce CloudWatch costs, and attribute EKS GPU expenses with Kubecost.",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "eks",
-        "ec2"
-      ],
-      "backends": [
-        "cloudwatch",
-        "amp",
-        "amg",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "instrumentation": "custom",
-      "status": "active",
-      "time_to_value_minutes": 30,
-      "last_validated": "2026-08-20",
-      "iac_available": [],
-      "partner_integrations": [],
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_billing.html",
-      "related_events": [
-        "cloudwatch",
-        "metrics"
-      ]
     },
     {
       "name": "Observability Maturity Model",
@@ -1257,55 +1287,7 @@
       ],
       "status": "active",
       "docs_link": "",
-      "last_validated": "2026-08-20"
-    },
-    {
-      "name": "Observability Strategy",
-      "slug": "observability-strategy",
-      "content_type": "guide",
-      "description": "Strategic guidance for IT leaders on tying observability to business outcomes, ROI framing, KPI selection, and SLA measurement with percentiles.",
-      "workload_type": [
-        "applications"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs",
-        "traces"
-      ],
-      "status": "active",
-      "docs_link": "https://docs.aws.amazon.com/whitepapers/latest/aws-caf-operations-perspective/observability.html",
-      "last_validated": "2026-08-20"
-    },
-    {
-      "name": "Patch and Node Management",
-      "slug": "patch-and-node-management",
-      "content_type": "solution",
-      "description": "Fleet management with AWS Systems Manager: patch baselines, tag-based patching, SSM Agent lifecycle, session management, automation, and compliance reporting",
-      "workload_type": [
-        "operations"
-      ],
-      "compute_platform": [
-        "ec2"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "logs",
-        "metrics"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 40,
-      "instrumentation": "custom",
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/systems-manager/latest/userguide/what-is-systems-manager.html",
-      "last_validated": "2026-08-20",
-      "related_events": []
+      "last_validated": "2024-09-30"
     },
     {
       "name": "Rust Custom Metrics",
@@ -1328,7 +1310,7 @@
       "instrumentation": "custom",
       "status": "active",
       "time_to_value_minutes": 20,
-      "last_validated": "2026-08-20",
+      "last_validated": "2024-09-30",
       "iac_available": [],
       "partner_integrations": [],
       "accelerator_link": "",


### PR DESCRIPTION
Two related problems. The pinned set had inverted its own purpose, and 46 of 48 dates were fabricated.

Recommended alarms guide was the freshest entry in the catalog and sat on page 3, because 18 pinned entries occupied pages 1 and 2. `featured` was introduced to keep reviewed content ahead of bulk-converted content, which made every genuinely new entry default to buried. That distinction should not exist anyway: anything merged has been reviewed.

Separately, `last_validated` was the date the conversion ran, not a date any human verified anything. Every entry claimed to be days old while some described approaches two years stale.

- Remove `featured` from all 18 entries. The field remains for a real editorial override, documented as rare, currently used by none.
- Derive each date from the last commit touching the source material the entry was built from, via `git log -1 --format=%cs`. Entries written fresh with no repo source fall back to their own first commit.
- Leave the two entries the colleague authored or reviewed untouched.
- Exclude this project's own edits from the calculation. The coding agents sources were touched yesterday by a link fix, which is not a revalidation, so that entry takes its real content vintage of 2026-06-22.

The result is that 12 of 48 entries now trip the 365-day staleness warning, which is the correct outcome: that is the re-test backlog, previously hidden behind fabricated dates. It independently confirms the ECS entry flagged as outdated by inspection, whose sources date to 2024-09-30, 690 days old.

The new alarms guide is now position 2 on page 1, and the oldest content sank to the end.

Documents in CONTRIBUTING.md that editing prose does not refresh the date, that conversions inherit the source's date, and how to obtain it.

