### PR TITLE
feat(catalog): Add needs-refresh status for entries behind current guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Each object in `solutions` carries:
 | `instrumentation` | single value; solutions only, may be absent |
 | `time_to_value_minutes` | integer; solutions only, may be absent |
 | `iac_available` | array, e.g. `terraform`, `cdk`; may be absent |
-| `status` | `active`, `deprecated`, or `preview` |
+| `status` | `active`, `needs-refresh`, `deprecated`, or `preview` |
 | `last_validated` | `YYYY-MM-DD`, the date a human last re-tested it |
 | `featured` | boolean, ordering only; may be absent |
 | `docs_link` | link to authoritative AWS documentation, may be empty |
@@ -171,6 +171,11 @@ Before authoring or modifying content, read:
   exception: Docusaurus bundles them at build time, so they resolve fine.
 - **The homepage is the catalog**, a React page, not a document. There is no
   index document to parse.
+- **`status: needs-refresh` means do not present this as current.** The topic is
+  right and the steps still work, but the recommendation is behind current AWS
+  guidance and a rework is pending. These entries sort last and carry a caution
+  admonition naming what is missing. Read that admonition before summarising the
+  entry, and prefer the AWS documentation it links to.
 - **`last_validated` is a promise, not a timestamp.** It means a human re-tested
   the steps. Do not update it unless that happened.
 - **Ordering is `featured`, then `last_validated` descending, then name.** It is

--- a/docusaurus/docs/solutions/_catalog/BACKLOG.md
+++ b/docusaurus/docs/solutions/_catalog/BACKLOG.md
@@ -27,6 +27,21 @@ site. Intended contents:
 contract file makes that usable by agents answering "how do I monitor X on AWS"
 without inventing steps.
 
+## Entries awaiting refresh (`status: needs-refresh`)
+
+Published and reachable, sorted last, badged on their cards. The generator lists
+them on every run. Each carries a caution admonition naming what is missing.
+
+- **ec2-nginx** — configures the CloudWatch agent directly; needs OpenTelemetry
+  collection into CloudWatch, a dashboard artifact, and real validation steps.
+- **kafka-ec2** — collects broker metrics over JMX via the agent's JMX plugin;
+  needs the OpenTelemetry JMX receiver, the CloudWatch managed Prometheus
+  collector as an alternative, and accelerator dashboards. Readers on Amazon MSK
+  should use `msk-monitoring`, which is current.
+- **lambda-monitoring** — leads with Lambda Insights; needs Application Signals
+  for Lambda, the AWS-managed OpenTelemetry Lambda layers, and Transaction
+  Search. Lambda Insights stays useful for memory and cold-start analysis.
+
 ## Other deferred items
 
 - **Delete the 257 retained source files** (scheduled: a few weeks out). All are

--- a/docusaurus/docs/solutions/_catalog/CONTRIBUTING.md
+++ b/docusaurus/docs/solutions/_catalog/CONTRIBUTING.md
@@ -233,6 +233,56 @@ Both should return nothing.
   checking covers these; the site build does not.
 - **Images**: see the images rule below.
 
+||||||| parent of f633caf42 (feat(catalog): Add needs-refresh status for entries behind current guidance)
+## When an entry falls behind: `needs-refresh`
+
+Sometimes an entry is not stale by date and not factually wrong, but its
+**recommendation is behind current AWS guidance**. The topic still matters, the
+steps still work, and it should be reworked rather than removed.
+
+Set `status: needs-refresh` and add a `:::caution` admonition after the Overview
+naming exactly what is missing, with links out.
+
+```yaml
+status: needs-refresh
+```
+
+What that does:
+
+- **Sorts the entry last**, ahead of nothing. This is the strongest ordering key,
+  stronger than `featured` and `last_validated`, because an entry behind current
+  guidance should not lead the catalog even when its date is recent.
+- **Renders a "Needs refresh" badge** on its card, so a reader knows before
+  clicking rather than after following the steps.
+- **Appears in generator output on every run**, which is the tracking mechanism.
+
+### Why the entry stays published
+
+Retiring it to an unrendered folder was considered and rejected. These are
+important topics with live URLs that may be linked or indexed, so removing them
+trades thin content for dead links. Hiding them also removes the pressure to fix
+them: content nobody can see is content nobody prioritises.
+
+The badge sets expectations; the ordering stops it being promoted; the generator
+report stops it being forgotten. Nothing moves on disk, so no redirects are
+needed.
+
+### Distinguish the three status values
+
+| `status` | Means | Card | Order |
+|---|---|---|---|
+| `active` | current | normal | by date |
+| `needs-refresh` | right topic, recommendation behind current guidance, rework pending | "Needs refresh" badge | last |
+| `deprecated` | approach superseded; retained for readers already on it | warning marker | by date |
+
+`deprecated` and `needs-refresh` differ in maintainer intent: a deprecated entry
+is on its way out, a needs-refresh entry is on its way to being rewritten.
+
+### Clearing it
+
+Set `status: active`, remove the admonition, and set `last_validated` to the date
+you actually verified the reworked steps.
+
 ## Catalog ordering and appearance
 
 `catalog.json` is **generated** — never hand-edit it. The generator reads every `meta.yaml`, validates it, and writes the catalog file.

--- a/docusaurus/docs/solutions/_catalog/schema.yaml
+++ b/docusaurus/docs/solutions/_catalog/schema.yaml
@@ -65,7 +65,7 @@ field_definitions:
     description: "Pin ahead of non-featured entries in catalog order. Curation only; does not affect filtering or search."
   status:
     type: string
-    allowed_values: [active, deprecated, preview]
+    allowed_values: [active, deprecated, preview, needs-refresh]
   accelerator_link:
     type: string
     format: url

--- a/docusaurus/docs/solutions/ec2-nginx/index.md
+++ b/docusaurus/docs/solutions/ec2-nginx/index.md
@@ -17,6 +17,24 @@ Key metrics captured:
 - Response time percentiles
 - Upstream connect/response time
 
+:::caution Needs refresh
+
+This entry predates the current recommendation. It configures the CloudWatch
+agent directly and does not cover:
+
+- **OpenTelemetry collection into CloudWatch**, now the preferred path for
+  application metrics on EC2
+- A **dashboard worth shipping** — there is no accelerator artifact referenced
+- Validation showing what a working NGINX monitoring setup looks like
+
+The steps below still work. Prefer the
+[AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html)
+when starting fresh, and see
+[CloudWatch Agent Configuration](../cloudwatch-agent-configuration/) for
+current agent guidance.
+
+:::
+
 ## Prerequisites
 
 - EC2 instance with NGINX installed

--- a/docusaurus/docs/solutions/ec2-nginx/meta.yaml
+++ b/docusaurus/docs/solutions/ec2-nginx/meta.yaml
@@ -10,7 +10,7 @@ iac_available: []
 partner_integrations: []
 time_to_value_minutes: 15
 instrumentation: cwagent
-status: active
+status: needs-refresh
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html"
 last_validated: "2026-08-18"

--- a/docusaurus/docs/solutions/kafka-ec2/index.md
+++ b/docusaurus/docs/solutions/kafka-ec2/index.md
@@ -15,6 +15,22 @@ Key metrics captured:
 - Consumer groups: consumer lag, commit rate
 - JVM: heap usage, GC time, thread count
 
+:::caution Needs refresh
+
+This entry collects Kafka broker metrics over JMX with the CloudWatch agent. It
+predates the current recommendation and does not cover:
+
+- **OpenTelemetry collection**, including the JMX receiver, which replaces the
+  agent's JMX plugin for new deployments
+- The **CloudWatch managed Prometheus collector** as an alternative for
+  self-managed Kafka
+- Dashboards from the observability accelerator artifacts
+
+The steps below still work. If you run **Amazon MSK** rather than self-managed
+Kafka, use [Amazon MSK Monitoring](../msk-monitoring/) instead, which is current.
+
+:::
+
 ## Prerequisites
 
 - Kafka cluster running on EC2 (v2.8+)

--- a/docusaurus/docs/solutions/kafka-ec2/meta.yaml
+++ b/docusaurus/docs/solutions/kafka-ec2/meta.yaml
@@ -10,7 +10,7 @@ iac_available: []
 partner_integrations: []
 time_to_value_minutes: 25
 instrumentation: cwagent
-status: active
+status: needs-refresh
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-jmx.html"
 last_validated: "2026-08-18"

--- a/docusaurus/docs/solutions/lambda-monitoring/index.md
+++ b/docusaurus/docs/solutions/lambda-monitoring/index.md
@@ -16,6 +16,23 @@ Key observability features:
 - Structured logging with embedded metric format (EMF)
 - Cost-per-invocation tracking
 
+:::caution Needs refresh
+
+This entry leads with Lambda Insights and native CloudWatch metrics. It predates
+the current recommendation and does not cover:
+
+- **CloudWatch Application Signals for Lambda**, which provides service-level
+  latency, error rate, and dependency mapping
+- The **AWS-managed OpenTelemetry Lambda layers** for OTLP export
+- **Transaction Search** for trace-level analysis
+
+The steps below still work and Lambda Insights remains useful for memory and
+cold-start analysis. Prefer
+[Application Signals](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html)
+as the starting point for new functions.
+
+:::
+
 ## Prerequisites
 
 - AWS Lambda function(s) deployed

--- a/docusaurus/docs/solutions/lambda-monitoring/meta.yaml
+++ b/docusaurus/docs/solutions/lambda-monitoring/meta.yaml
@@ -10,7 +10,7 @@ iac_available: [cdk, terraform, cloudformation]
 partner_integrations: []
 time_to_value_minutes: 10
 instrumentation: cwagent
-status: active
+status: needs-refresh
 accelerator_link: ""
 docs_link: "https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html"
 last_validated: "2026-08-18"

--- a/docusaurus/scripts/generate-catalog.py
+++ b/docusaurus/scripts/generate-catalog.py
@@ -57,7 +57,7 @@ REQUIRED_FIELDS = {
 }
 
 VALID_CONTENT_TYPES = ("solution", "guide")
-VALID_STATUSES = ("active", "deprecated", "preview")
+VALID_STATUSES = ("active", "deprecated", "preview", "needs-refresh")
 VALID_IAC = ("terraform", "cdk", "cloudformation", "pulumi")
 
 SLUG_PATTERN = re.compile(r"^[a-z0-9-]+$")
@@ -336,14 +336,19 @@ def main() -> None:
         print(f"  {label}  {entry.name}/ -> {meta.get('name', 'UNNAMED')}")
 
     # Ordering, applied as a stable sort chain from weakest key to strongest:
-    #   1. name          - deterministic tiebreaker
+    #   1. name           - deterministic tiebreaker
     #   2. last_validated - freshest first, so stale content sinks
     #   3. featured       - curated entries lead regardless of date
+    #   4. needs-refresh  - sinks to the end whatever else is true
     # `featured` exists so ordering can be curated without falsifying
     # last_validated, which is a re-test promise the validator checks.
+    # `needs-refresh` is the strongest key deliberately: an entry whose
+    # recommendation is behind current guidance should not lead the catalog even
+    # if its date is recent, which is exactly how these entries reached page one.
     solutions.sort(key=lambda s: str(s.get("name", "")))
     solutions.sort(key=lambda s: str(s.get("last_validated", "")), reverse=True)
     solutions.sort(key=lambda s: bool(s.get("featured", False)), reverse=True)
+    solutions.sort(key=lambda s: s.get("status") == "needs-refresh")
 
     if findings.warnings:
         print(f"\n{len(findings.warnings)} warning(s):")
@@ -359,6 +364,17 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Surface entries awaiting rework on every run. Keeping them published
+    # avoids dead links on important topics; listing them here is what stops
+    # "someone will refresh it" from meaning nobody.
+    needs = sorted(s.get("slug", "?") for s in solutions
+                   if s.get("status") == "needs-refresh")
+    if needs:
+        print(f"\n{len(needs)} entr{'y' if len(needs)==1 else 'ies'} awaiting refresh "
+              f"(published, sorted last):")
+        for slug in needs:
+            print(f"  {slug}")
 
     if args.check:
         print(f"\nValidated {len(solutions)} entries. No errors. (--check: nothing written)")

--- a/docusaurus/src/pages/index.tsx
+++ b/docusaurus/src/pages/index.tsx
@@ -10,7 +10,7 @@ interface Solution {
   description: string;
   workload_type: string[];
   signals: string[];
-  status: 'active' | 'deprecated' | 'preview';
+  status: 'active' | 'deprecated' | 'preview' | 'needs-refresh';
   last_validated?: string;
   content_type?: 'solution' | 'guide';
   // Solution-only fields — guides legitimately omit these.
@@ -107,6 +107,7 @@ function buildHaystack(sol: Solution): string {
     instrumentation,
     ...(sol.iac_available ?? []),
     sol.content_type || '',
+    sol.status === 'needs-refresh' ? 'needs refresh rework outdated' : '',
     ...(sol.search_keywords ?? []),
   ];
   // Expand synonyms so "grafana" finds AMG entries, "kubernetes" finds EKS, etc.
@@ -369,6 +370,14 @@ export default function SolutionsPage(): React.ReactElement {
                     {sol.name}
                   </h3>
                   <div className={styles.cardBadges}>
+                    {/* Sets expectations before the click. These entries stay
+                        published because the topics matter and the URLs are
+                        live; the badge is what stops them reading as current. */}
+                    {sol.status === 'needs-refresh' && (
+                      <span className={styles.needsRefresh} title="Recommendation is behind current AWS guidance; rework pending">
+                        Needs refresh
+                      </span>
+                    )}
                     {sol.content_type && (
                       <span className={`${styles.typeTag} ${sol.content_type === 'guide' ? styles.typeGuide : styles.typeSolution}`}>
                         {sol.content_type === 'guide' ? 'Guide' : 'Solution'}

--- a/docusaurus/src/pages/solutions.module.css
+++ b/docusaurus/src/pages/solutions.module.css
@@ -352,3 +352,27 @@
   color: var(--ifm-color-emphasis-500);
   white-space: nowrap;
 }
+
+/* Entries whose recommendation is behind current guidance. Amber rather than
+   red: the topic is still right and the content is still largely usable, so
+   this is a caution, not a rejection. */
+.needsRefresh {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  border-radius: 4px;
+  background: #fff4e5;
+  color: #8a5300;
+  border: 1px solid #f0c893;
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .needsRefresh {
+  background: rgba(240, 200, 147, 0.14);
+  color: #f0c893;
+  border-color: rgba(240, 200, 147, 0.35);
+}

--- a/docusaurus/static/catalog.json
+++ b/docusaurus/static/catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-22T03:41:25.152897+00:00",
+  "generated_at": "2026-08-22T04:30:23.492047+00:00",
   "schema_version": "1.0",
   "solutions": [
     {
@@ -105,33 +105,6 @@
       ]
     },
     {
-      "name": "EC2 NGINX Monitoring",
-      "slug": "ec2-nginx",
-      "content_type": "solution",
-      "description": "Monitor NGINX web servers on EC2 using CloudWatch Agent with StatsD and custom metrics",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "ec2"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 15,
-      "instrumentation": "cwagent",
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html",
-      "last_validated": "2026-08-18"
-    },
-    {
       "name": "EKS Java Application Monitoring",
       "slug": "eks-application-signals",
       "content_type": "solution",
@@ -162,67 +135,6 @@
       "status": "active",
       "accelerator_link": "",
       "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals.html",
-      "last_validated": "2026-08-18"
-    },
-    {
-      "name": "Kafka on EC2 Monitoring",
-      "slug": "kafka-ec2",
-      "content_type": "solution",
-      "description": "Monitor self-managed Apache Kafka clusters on EC2 using CloudWatch Agent JMX plugin for broker and consumer metrics",
-      "workload_type": [
-        "data-streaming",
-        "compute"
-      ],
-      "compute_platform": [
-        "ec2"
-      ],
-      "backends": [
-        "cloudwatch"
-      ],
-      "signals": [
-        "metrics",
-        "logs"
-      ],
-      "iac_available": [],
-      "partner_integrations": [],
-      "time_to_value_minutes": 25,
-      "instrumentation": "cwagent",
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-jmx.html",
-      "last_validated": "2026-08-18"
-    },
-    {
-      "name": "Lambda Monitoring",
-      "slug": "lambda-monitoring",
-      "content_type": "solution",
-      "description": "Comprehensive AWS Lambda monitoring with CloudWatch native metrics, X-Ray tracing, and Lambda Insights",
-      "workload_type": [
-        "compute"
-      ],
-      "compute_platform": [
-        "lambda"
-      ],
-      "backends": [
-        "cloudwatch",
-        "xray"
-      ],
-      "signals": [
-        "metrics",
-        "traces",
-        "logs"
-      ],
-      "iac_available": [
-        "cdk",
-        "terraform",
-        "cloudformation"
-      ],
-      "partner_integrations": [],
-      "time_to_value_minutes": 10,
-      "instrumentation": "cwagent",
-      "status": "active",
-      "accelerator_link": "",
-      "docs_link": "https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html",
       "last_validated": "2026-08-18"
     },
     {
@@ -1290,6 +1202,94 @@
       "related_events": [
         "metrics"
       ]
+    },
+    {
+      "name": "EC2 NGINX Monitoring",
+      "slug": "ec2-nginx",
+      "content_type": "solution",
+      "description": "Monitor NGINX web servers on EC2 using CloudWatch Agent with StatsD and custom metrics",
+      "workload_type": [
+        "compute"
+      ],
+      "compute_platform": [
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 15,
+      "instrumentation": "cwagent",
+      "status": "needs-refresh",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html",
+      "last_validated": "2026-08-18"
+    },
+    {
+      "name": "Kafka on EC2 Monitoring",
+      "slug": "kafka-ec2",
+      "content_type": "solution",
+      "description": "Monitor self-managed Apache Kafka clusters on EC2 using CloudWatch Agent JMX plugin for broker and consumer metrics",
+      "workload_type": [
+        "data-streaming",
+        "compute"
+      ],
+      "compute_platform": [
+        "ec2"
+      ],
+      "backends": [
+        "cloudwatch"
+      ],
+      "signals": [
+        "metrics",
+        "logs"
+      ],
+      "iac_available": [],
+      "partner_integrations": [],
+      "time_to_value_minutes": 25,
+      "instrumentation": "cwagent",
+      "status": "needs-refresh",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-jmx.html",
+      "last_validated": "2026-08-18"
+    },
+    {
+      "name": "Lambda Monitoring",
+      "slug": "lambda-monitoring",
+      "content_type": "solution",
+      "description": "Comprehensive AWS Lambda monitoring with CloudWatch native metrics, X-Ray tracing, and Lambda Insights",
+      "workload_type": [
+        "compute"
+      ],
+      "compute_platform": [
+        "lambda"
+      ],
+      "backends": [
+        "cloudwatch",
+        "xray"
+      ],
+      "signals": [
+        "metrics",
+        "traces",
+        "logs"
+      ],
+      "iac_available": [
+        "cdk",
+        "terraform",
+        "cloudformation"
+      ],
+      "partner_integrations": [],
+      "time_to_value_minutes": 10,
+      "instrumentation": "cwagent",
+      "status": "needs-refresh",
+      "accelerator_link": "",
+      "docs_link": "https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html",
+      "last_validated": "2026-08-18"
     }
   ],
   "taxonomy": {


### PR DESCRIPTION
Three entries flagged as outdated in recommendation, not date, were sitting at positions 3, 6 and 7 on page one. They ranked there precisely because nobody had validated them: with no repo source to inherit a date from, the honest-dates pass gave them their authoring date, which is recent.

`featured: false` was considered and does not work. The field is now absent from every entry, so absent already means false; making absent, false and true all meaningful would be a three-state flag nobody remembers. Extends the existing `status` field instead, which is already validated.

`status: needs-refresh`:

- sorts last, as the strongest ordering key, ahead of featured and last_validated, because an entry behind current guidance should not lead the catalog even when its date is recent
- renders a "Needs refresh" badge on the card, amber rather than red, since the topic is right and the content is largely usable
- is reported by the generator on every run, which is the tracking
- is searchable, so an audit can find these by typing "needs refresh"

Applied to ec2-nginx, kafka-ec2 and lambda-monitoring, each with a caution admonition naming what is actually missing: OpenTelemetry collection and a dashboard artifact for NGINX; the OpenTelemetry JMX receiver and managed collector for Kafka, pointing MSK readers at msk-monitoring; and Application Signals, the managed OTel Lambda layers, and Transaction Search for Lambda.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

